### PR TITLE
Add basic dashboard layout with sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # TRC SalesGPT Frontend
 
-This is the frontend for TRC SalesGPT. To connect Microsoft, click the button on the homepage.
+This project uses Next.js to present a simple dashboard. It includes a sidebar with links for a team section, knowledge base, retailer forecasting tool and a quick response helper. A **Connect Outlook** button in the header demonstrates how you might start an OAuth flow to Microsoft.
+
+The dashboard currently shows placeholder email metrics. In a real deployment you would call the Microsoft Graph API to fetch emails and compute metrics such as how many emails each person has sent and the average response time.
+
+## Development
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import styles from '../styles/Header.module.css';
+
+export default function Header({ onConnect }) {
+  return (
+    <header className={styles.header}>
+      <h1>Sales Dashboard</h1>
+      <button onClick={onConnect}>Connect Outlook</button>
+    </header>
+  );
+}

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from '../styles/Sidebar.module.css';
+
+export default function Sidebar() {
+  return (
+    <aside className={styles.sidebar}>
+      <nav>
+        <ul>
+          <li>Team</li>
+          <li>Internal Knowledge Base</li>
+          <li>Retailer Forecasting Tool</li>
+          <li>Quick Response</li>
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,21 +1,53 @@
-
 import Head from 'next/head';
+import { useState, useEffect } from 'react';
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import styles from '../styles/Home.module.css';
 
 export default function Home() {
+  const [emails, setEmails] = useState([]);
+  const [metrics, setMetrics] = useState({});
+
   const handleConnect = async () => {
+    // Redirect to your Microsoft OAuth flow
     window.location.href = 'https://trc-salesgpt-backend.onrender.com/auth/start';
   };
 
-  return (
-    <div style={{ padding: '40px' }}>
-      <Head>
-        <title>TRC SalesGPT</title>
-        <meta name="description" content="Connect Microsoft Account" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+  useEffect(() => {
+    // Placeholder for fetching messages from Microsoft Graph API
+    const dummyEmails = [
+      { sender: 'alice@example.com', responseTimeDays: 1 },
+      { sender: 'bob@example.com', responseTimeDays: 2 },
+      { sender: 'alice@example.com', responseTimeDays: 3 }
+    ];
+    setEmails(dummyEmails);
+  }, []);
 
-      <h1 style={{ fontSize: '2.5rem' }}>Welcome to TRC SalesGPT</h1>
-      <button onClick={handleConnect}>Connect Microsoft</button>
+  useEffect(() => {
+    // Compute simple metrics using dummy data
+    const counts = {};
+    let totalResponse = 0;
+    emails.forEach((e) => {
+      counts[e.sender] = (counts[e.sender] || 0) + 1;
+      totalResponse += e.responseTimeDays;
+    });
+    const avgResponse = emails.length ? (totalResponse / emails.length).toFixed(2) : 0;
+    setMetrics({ counts, avgResponse });
+  }, [emails]);
+
+  return (
+    <div className={styles.container}>
+      <Head>
+        <title>TRC SalesGPT Dashboard</title>
+      </Head>
+      <Header onConnect={handleConnect} />
+      <div className={styles.content}>
+        <Sidebar />
+        <main className={styles.main}>
+          <h2>Email Metrics</h2>
+          <pre>{JSON.stringify(metrics, null, 2)}</pre>
+        </main>
+      </div>
     </div>
   );
 }

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -1,0 +1,7 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #f0f0f0;
+  padding: 10px 20px;
+}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,15 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.content {
+  display: flex;
+  flex: 1;
+}
+
+.main {
+  flex: 1;
+  padding: 20px;
+}

--- a/styles/Sidebar.module.css
+++ b/styles/Sidebar.module.css
@@ -1,0 +1,15 @@
+.sidebar {
+  width: 200px;
+  background-color: #fafafa;
+  padding: 20px;
+  height: 100vh;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+}
+
+.sidebar li {
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- add header with connect button
- add sidebar with section placeholders
- show placeholder email metrics on homepage
- document setup in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cffb37ea8832092ce9cc803faa0ec