### PR TITLE
Add sales rep dropdown and PDF disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # TRC SalesGPT Frontend
 
-This is the frontend for TRC SalesGPT. To connect Microsoft, click the button on the homepage.
+This project contains a small Next.js frontend for the TRC SalesGPT demo.
+
+## Getting started
+
+1. Run `npm install` to install dependencies.
+2. Use `npm run dev` to start the development server or `npm run build` to build for production.
+
+## Features
+
+ - **Forecasting tool** – The homepage hosts **The Reward Collection Forecasting Tool**. Select the sales rep, choose multiple regions and tier, and specify online/instore options and cashback rates. Reach for each region auto-fills from publisher data and is halved to reflect realistic campaign performance. When a campaign is new‑customer only, reach is first limited to publishers that support new customers before the 50% reduction. Results include a six-month growth curve with tables showing revenue, total cashback, **net revenue** and sales. Currency is chosen automatically (GBP for UK, USD for US, EUR for EU or whichever region contributes the most sales). The results heading displays the retailer name followed by "6-Month Forecast". The interface loads in light mode by default, with a toggle at the top right to switch to dark mode. A **Download PDF** button saves the forecast without the view controls and includes a note from the chosen sales rep. When both online and in-store are selected, another table splits results by channel and appears in the **View All** display.
+- **Publisher manager** – Use the Publishers link to view, add or edit publisher entries that feed the automated reach numbers.

--- a/lib/usePublishers.js
+++ b/lib/usePublishers.js
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+
+export const DEFAULT_PUBLISHERS = [
+  { id: 1, network: 'Loyalty Key', sub: 'Visa B2C, Loyalty Key', regions: ['EU'], reach: 300000, newCustomers: true },
+  { id: 2, network: 'LUX', sub: 'Revolut', regions: ['EU'], reach: 18000000, newCustomers: false },
+  { id: 3, network: 'Pluxee', sub: 'Spreecard, Airtime, SuitsMe Card, Anna Money', regions: ['UK'], reach: 3500000, newCustomers: false },
+  { id: 4, network: 'LUX', sub: 'Mastercard B2B', regions: ['UK'], reach: 3600000, newCustomers: false },
+  { id: 5, network: 'LUX', sub: 'Revolut', regions: ['UK'], reach: 9000000, newCustomers: false },
+  { id: 6, network: 'LUX', sub: 'Hyperjar', regions: ['UK'], reach: 600000, newCustomers: false },
+  { id: 7, network: 'LUX', sub: 'Boogi: Capital On Tap, Give As You Live', regions: ['UK'], reach: 565000, newCustomers: true },
+  { id: 9, network: 'Fidel', sub: 'Tenerity, Weselyan, Squaremeal, Next Jump, Topcashback, Complete Savings, Zilch', regions: ['UK'], reach: 1100000, newCustomers: false },
+  { id:10, network: 'Collinson', sub: 'British Airways, Aerlingus', regions: ['UK'], reach: 1000000, newCustomers: false },
+  { id:11, network: 'Collinson', sub: 'Tide Bank', regions: ['UK'], reach: 690000, newCustomers: true },
+  { id:12, network: 'Curve', sub: 'Curve', regions: ['UK'], reach: 400000, newCustomers: false },
+  { id:13, network: 'Pockit Ltd', sub: 'Pockit', regions: ['UK'], reach: 900000, newCustomers: false },
+  { id:14, network: 'Railsr', sub: 'Pay IO (B2B)', regions: ['UK'], reach: 2000000, newCustomers: false },
+  { id:15, network: 'LUX', sub: 'Mastercard B2B', regions: ['US'], reach: 17000000, newCustomers: false },
+  { id:16, network: 'LUX', sub: 'Revolut', regions: ['US'], reach: 1000000, newCustomers: false },
+  { id:17, network: 'Collinson', sub: 'JetBlue, Emirates, NCR, American Airlines, Simply Miles, Flying Blue, Virgin', regions: ['US'], reach: 16000000, newCustomers: true },
+  { id:18, network: 'Fidel USA', sub: 'Dolr, Percents, Viffy', regions: ['US'], reach: 100000, newCustomers: false },
+  { id:19, network: 'Fidel USA', sub: 'Cashapp', regions: ['US'], reach: 88000000, newCustomers: true },
+  { id:20, network: 'Fidel USA', sub: 'PNC', regions: ['US'], reach: 9000000, newCustomers: true },
+  { id:21, network: 'Fidel USA', sub: 'Bank Of America', regions: ['US'], reach: 50000000, newCustomers: true },
+  { id:22, network: 'Fidel USA', sub: 'Visa B2B', regions: ['US'], reach: 1200000, newCustomers: false },
+  { id:23, network: 'Fidel USA', sub: 'American Express', regions: ['US'], reach: 70000000, newCustomers: true },
+  { id:24, network: 'Fidel USA', sub: 'Barclays', regions: ['US'], reach: 8000000, newCustomers: true },
+  { id:25, network: 'Fidel USA', sub: 'Citadel Credit Union', regions: ['US'], reach: 100000, newCustomers: true },
+  { id:26, network: 'Fidel USA', sub: 'Citizens Bank', regions: ['US'], reach: 4000000, newCustomers: true },
+  { id:27, network: 'Olive', sub: 'NCAA, American Cancer Society, YouthSport, WorldVision, Shop.com, QuestTrade, Price.com', regions: ['US'], reach: 500000, newCustomers: false },
+  { id:28, network: 'Drop', sub: 'Acorns', regions: ['US'], reach: 10000000, newCustomers: true },
+  { id:29, network: 'Drop', sub: 'AFS (Affinity Financial Solutions)', regions: ['US'], reach: 17000000, newCustomers: true },
+];
+
+export function usePublishers() {
+  const [publishers, setPublishers] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('publishers');
+    if (stored) {
+      try {
+        setPublishers(JSON.parse(stored));
+        return;
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    setPublishers(DEFAULT_PUBLISHERS);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('publishers', JSON.stringify(publishers));
+  }, [publishers]);
+
+  return [publishers, setPublishers];
+}
+
+export function computeReach(publishers, region, includeNew) {
+  return publishers
+    .filter((p) => p.regions.includes(region) && (!includeNew || p.newCustomers))
+    .reduce((sum, p) => sum + p.reach, 0);
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,4 @@
+import '../styles/globals.css';
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,17 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html data-theme="light">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,21 +1,651 @@
-
+import { useState, useEffect, useRef } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
+import { usePublishers, computeReach } from '../lib/usePublishers';
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
 
-export default function Home() {
-  const handleConnect = async () => {
-    window.location.href = 'https://trc-salesgpt-backend.onrender.com/auth/start';
+const REGIONS = ['UK', 'US', 'EU'];
+const SALES_REPS = ['james', 'lucy', 'rebecca', 'ryan', 'preena', 'shamas', 'shaun'];
+
+// Conversion rates by tier. Reduced by 50% from the previous values so
+// forecasts are more conservative.
+const CONVERSION_BY_TIER = {
+  1: 0.0005,
+  2: 0.00025,
+  3: 0.000125,
+  4: 0.0000625,
+  5: 0.0000425,
+  6: 0.000025,
+};
+
+const MONTH_DELTAS = [0, 0.05, 0.07, -0.02, 0.06, 0.04];
+
+
+function formatNumber(n) {
+  return n.toLocaleString();
+}
+
+const REGION_CURRENCIES = {
+  UK: 'GBP',
+  US: 'USD',
+  EU: 'EUR',
+};
+
+const CURRENCY_SYMBOLS = {
+  GBP: '£',
+  USD: '$',
+  EUR: '€',
+};
+
+function formatCurrency(n, code) {
+  const symbol = CURRENCY_SYMBOLS[code] || '';
+  return (
+    symbol +
+    n.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  );
+}
+
+export default function Forecast() {
+  const [retailer, setRetailer] = useState('');
+  const [rep, setRep] = useState(SALES_REPS[0]);
+  const [regions, setRegions] = useState([]);
+  const [tier, setTier] = useState('1');
+  const [online, setOnline] = useState(false);
+  const [instore, setInstore] = useState(false);
+  const [stores, setStores] = useState('');
+  const [aov, setAov] = useState('');
+  const [reach, setReach] = useState({});
+  const [publishers] = usePublishers();
+  const [cashbackExisting, setCashbackExisting] = useState('');
+  const [cashbackNew, setCashbackNew] = useState('');
+  const [results, setResults] = useState(null);
+  const [view, setView] = useState('global');
+  const [theme, setTheme] = useState('light');
+  const resultsRef = useRef(null);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    const newOnly =
+      parseFloat(cashbackNew) > 0 && (!cashbackExisting || parseFloat(cashbackExisting) === 0);
+    const obj = {};
+    regions.forEach((r) => {
+      const baseReach = computeReach(publishers, r, newOnly);
+      obj[r] = Math.round(baseReach * 0.5);
+    });
+    setReach(obj);
+  }, [regions, cashbackExisting, cashbackNew, publishers]);
+
+  const GlobalView = () => (
+    <table className="summary-table">
+      <tbody>
+        <tr>
+          <th>Expected Orders</th>
+          <td>{formatNumber(Math.round(results.total.orders))}</td>
+        </tr>
+        <tr>
+          <th>Revenue</th>
+          <td>
+            {formatCurrency(results.total.revenue, results.currency)}
+          </td>
+        </tr>
+        <tr>
+          <th>Total Cashback</th>
+          <td>
+            {formatCurrency(results.total.cashback, results.currency)}
+          </td>
+        </tr>
+        <tr>
+          <th>Net Revenue</th>
+          <td>
+            {formatCurrency(results.total.netRevenue, results.currency)}
+          </td>
+        </tr>
+        <tr>
+          <th>ROAS</th>
+          <td>{results.total.roas.toFixed(2)}x</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+
+  const RegionView = () => (
+    <table className="monthly-table">
+      <thead>
+        <tr>
+          <th>Region</th>
+          <th>Orders</th>
+          <th>Revenue</th>
+          <th>Total Cashback</th>
+          <th>Net Revenue</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Object.entries(results.perRegion).map(([r, d]) => (
+          <tr key={r}>
+            <td>
+              {r} ({CURRENCY_SYMBOLS[REGION_CURRENCIES[r]]})
+            </td>
+            <td>{formatNumber(Math.round(d.orders))}</td>
+            <td>{formatCurrency(d.revenue, REGION_CURRENCIES[r])}</td>
+            <td>{formatCurrency(d.cashback, REGION_CURRENCIES[r])}</td>
+            <td>{formatCurrency(d.netRevenue, REGION_CURRENCIES[r])}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  const OfferView = () => (
+    results.offerBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.offerBreakdown).map(([t, d]) => (
+            <tr key={t}>
+              <td>{t}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue, results.currency)}</td>
+              <td>{formatCurrency(d.cashback, results.currency)}</td>
+              <td>{formatCurrency(d.netRevenue, results.currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+  const ChannelView = () => (
+    results.channelBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.channelBreakdown).map(([c, d]) => (
+            <tr key={c}>
+              <td>{c}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue, results.currency)}</td>
+              <td>{formatCurrency(d.cashback, results.currency)}</td>
+              <td>{formatCurrency(d.netRevenue, results.currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+
+  const toggleRegion = (region) => {
+    setRegions((prev) => {
+      if (prev.includes(region)) {
+        const updated = prev.filter((r) => r !== region);
+        setReach((curr) => {
+          const copy = { ...curr };
+          delete copy[region];
+          return copy;
+        });
+        return updated;
+      }
+      setReach((curr) => ({ ...curr, [region]: '' }));
+      return [...prev, region];
+    });
+  };
+
+  const calculate = (e) => {
+    e.preventDefault();
+
+    const storeCount = parseInt(stores, 10) || 0;
+    const baseConversion = CONVERSION_BY_TIER[tier] || 0;
+    const storeUplift = instore && storeCount > 0 ? storeCount * 0.000001 : 0;
+    const conversion = baseConversion + storeUplift;
+
+    const aovNum = parseFloat(aov) || 0;
+    const existingCb = parseFloat(cashbackExisting) || 0;
+    const newCb = parseFloat(cashbackNew) || 0;
+
+    const perRegion = {};
+    let totalOrders = 0;
+    let onlineOrdersTotal = 0;
+    let instoreOrdersTotal = 0;
+    regions.forEach((r) => {
+      const regionReach = parseInt(reach[r], 10) || 0;
+      let onlineOrders = 0;
+      let instoreOrders = 0;
+      if (online && instore) {
+        onlineOrders = regionReach * baseConversion;
+        instoreOrders = regionReach * storeUplift;
+      } else if (instore && !online) {
+        instoreOrders = regionReach * conversion;
+      } else {
+        onlineOrders = regionReach * baseConversion;
+      }
+      const orders = onlineOrders + instoreOrders;
+      perRegion[r] = { orders };
+      totalOrders += orders;
+      onlineOrdersTotal += onlineOrders;
+      instoreOrdersTotal += instoreOrders;
+    });
+
+    let existingOrders = 0;
+    let newOrders = 0;
+
+    const hasExisting = existingCb > 0;
+    const hasNew = newCb > 0;
+
+    const computeAmounts = (orders) => {
+      const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
+      const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
+      const revenue = orders * aovNum;
+      const cashback =
+        orders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
+      return {
+        orders,
+        revenue,
+        cashback,
+        netRevenue: revenue - cashback,
+      };
+    };
+
+    if (hasExisting && hasNew) {
+      existingOrders = totalOrders * 0.6;
+      newOrders = totalOrders * 0.4;
+    } else if (hasNew && !hasExisting) {
+      newOrders = totalOrders * 0.4;
+      totalOrders = newOrders;
+    } else {
+      existingOrders = totalOrders;
+    }
+
+    const channelBreakdown =
+      online && instore
+        ? {
+            online: computeAmounts(onlineOrdersTotal),
+            instore: computeAmounts(instoreOrdersTotal),
+          }
+        : null;
+
+    const { revenue, cashback: cashbackAmount, netRevenue } =
+      computeAmounts(totalOrders);
+    const roas = cashbackAmount ? revenue / cashbackAmount : 0;
+
+    Object.keys(perRegion).forEach((r) => {
+      const orders = perRegion[r].orders;
+      let ex = 0;
+      let nw = 0;
+      if (hasExisting && hasNew) {
+        ex = orders * 0.6;
+        nw = orders * 0.4;
+      } else if (hasNew && !hasExisting) {
+        nw = orders * 0.4;
+      } else {
+        ex = orders;
+      }
+      const rev = orders * aovNum;
+      const cashbackAmount =
+        ex * aovNum * (existingCb / 100) + nw * aovNum * (newCb / 100);
+      perRegion[r] = {
+        orders,
+        revenue: rev,
+        cashback: cashbackAmount,
+        netRevenue: rev - cashbackAmount,
+      };
+    });
+
+    const factors = [1];
+    for (let i = 1; i < MONTH_DELTAS.length; i++) {
+      factors[i] = factors[i - 1] * (1 + MONTH_DELTAS[i]);
+    }
+    const sumFactors = factors.reduce((a, b) => a + b, 0);
+    const monthly = factors.map((f) => {
+      const monthOrders = (totalOrders * f) / sumFactors;
+      const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
+      const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
+      const monthRevenue = monthOrders * aovNum;
+      const monthCashback =
+        monthOrders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
+      return {
+        orders: monthOrders,
+        revenue: monthRevenue,
+        cashback: monthCashback,
+        netRevenue: monthRevenue - monthCashback,
+      };
+    });
+
+    const offerBreakdown =
+      hasExisting && hasNew
+        ? {
+            existing: {
+              orders: existingOrders,
+              revenue: existingOrders * aovNum,
+              cashback: existingOrders * aovNum * (existingCb / 100),
+              netRevenue:
+                existingOrders * aovNum -
+                existingOrders * aovNum * (existingCb / 100),
+            },
+            new: {
+              orders: newOrders,
+              revenue: newOrders * aovNum,
+              cashback: newOrders * aovNum * (newCb / 100),
+              netRevenue: newOrders * aovNum - newOrders * aovNum * (newCb / 100),
+            },
+          }
+        : null;
+
+    let bestRegion = regions[0];
+    let maxOrders = perRegion[bestRegion]?.orders || 0;
+    regions.forEach((r) => {
+      if ((perRegion[r]?.orders || 0) > maxOrders) {
+        bestRegion = r;
+        maxOrders = perRegion[r].orders;
+      }
+    });
+    const currency = REGION_CURRENCIES[bestRegion] || 'GBP';
+
+    setResults({
+      total: {
+        orders: totalOrders,
+        revenue,
+        cashback: cashbackAmount,
+        netRevenue,
+        roas,
+      },
+      perRegion,
+      monthly,
+      offerBreakdown,
+      channelBreakdown,
+      currency,
+    });
+  };
+
+  const downloadPdf = async () => {
+    if (!resultsRef.current) return;
+    const canvas = await html2canvas(resultsRef.current);
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF('p', 'mm', 'a4');
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const imgWidth = pageWidth;
+    const imgHeight = (canvas.height * imgWidth) / canvas.width;
+    let position = 0;
+    pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+    let heightLeft = imgHeight - pdf.internal.pageSize.getHeight();
+    while (heightLeft > 0) {
+      position -= pdf.internal.pageSize.getHeight();
+      pdf.addPage();
+      pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+      heightLeft -= pdf.internal.pageSize.getHeight();
+    }
+    const fileName = retailer ? `${retailer}-6-month-forecast.pdf` : '6-month-forecast.pdf';
+    pdf.save(fileName);
   };
 
   return (
-    <div style={{ padding: '40px' }}>
+    <>
       <Head>
-        <title>TRC SalesGPT</title>
-        <meta name="description" content="Connect Microsoft Account" />
-        <link rel="icon" href="/favicon.ico" />
+        <title>The Reward Collection Forecasting Tool</title>
       </Head>
+      <main className="container">
+        <div className="top-bar">
+          <Link href="/publishers">Publishers</Link>
+          <div className="theme-switch">
+            <button
+              type="button"
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            >
+              {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+            </button>
+          </div>
+        </div>
+        <h1>The Reward Collection Forecasting Tool</h1>
+        <p style={{ textAlign: 'center' }}>
+          Enter campaign details below to estimate performance.
+        </p>
+          <form onSubmit={calculate} className="form">
+            <label className="full-width">
+              Sales Rep
+              <select value={rep} onChange={(e) => setRep(e.target.value)}>
+                {SALES_REPS.map((r) => (
+                  <option key={r} value={r}>
+                    {r.charAt(0).toUpperCase() + r.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="full-width">
+              Retailer Name
+              <input
+                type="text"
+                value={retailer}
+                onChange={(e) => setRetailer(e.target.value)}
+                required
+              />
+            </label>
+            <fieldset className="region-group full-width">
+              <legend>Regions</legend>
+              {REGIONS.map((r) => (
+                <label key={r} className="checkbox">
+                  <input
+                    type="checkbox"
+                  checked={regions.includes(r)}
+                  onChange={() => toggleRegion(r)}
+                />
+                {r}
+              </label>
+            ))}
+          </fieldset>
+            {regions.map((r) => (
+              <label key={`reach-${r}`} className="reach-input">
+                Reach {r}
+                <input
+                  type="text"
+                  value={reach[r] ? formatNumber(reach[r]) : ''}
+                  onChange={(e) =>
+                    setReach((curr) => ({
+                      ...curr,
+                      [r]: parseInt(e.target.value.replace(/,/g, ''), 10) || 0,
+                    }))
+                  }
+                />
+              </label>
+            ))}
+          <label>
+            Tier
+            <select value={tier} onChange={(e) => setTier(e.target.value)}>
+              {[1, 2, 3, 4, 5, 6].map((t) => (
+                <option key={t} value={t}>
+                  Tier {t}
+                </option>
+              ))}
+            </select>
+          </label>
+            <div className="checkbox-row">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={online}
+                  onChange={(e) => setOnline(e.target.checked)}
+                />
+                Online
+              </label>
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={instore}
+                  onChange={(e) => setInstore(e.target.checked)}
+                />
+                In-store
+              </label>
+            </div>
+          {instore && (
+            <label>
+              Number of Stores
+              <input
+                type="number"
+                value={stores}
+                onChange={(e) => setStores(e.target.value)}
+                min="0"
+              />
+            </label>
+          )}
+          <label>
+            Average Order Value
+            <input
+              type="number"
+              value={aov}
+              onChange={(e) => setAov(e.target.value)}
+            />
+          </label>
+          <label>
+            Cashback Existing %
+            <input
+              type="number"
+              value={cashbackExisting}
+              onChange={(e) => setCashbackExisting(e.target.value)}
+            />
+          </label>
+          <label>
+            Cashback New %
+            <input
+              type="number"
+              value={cashbackNew}
+              onChange={(e) => setCashbackNew(e.target.value)}
+            />
+          </label>
+          <button type="submit" className="full-width">Calculate Forecast</button>
+        </form>
+        {results && (
+          <div className="results">
+            <div className="view-toggle">
+              <select value={view} onChange={(e) => setView(e.target.value)}>
+                <option value="global">High Level Campaign Metrics</option>
+                <option value="region">By Region</option>
+                {results.offerBreakdown && (
+                  <option value="offer">By Offer Type</option>
+                )}
+                {results.channelBreakdown && (
+                  <option value="channel">By Channel</option>
+                )}
+                <option value="all">View All</option>
+              </select>
+              <button type="button" onClick={downloadPdf}>Download PDF</button>
+            </div>
+            <div ref={resultsRef}>
+            <h2>{retailer ? `${retailer} 6-Month Forecast` : '6-Month Forecast'}</h2>
+            {view === 'global' && <GlobalView />}
+            {view === 'region' && <RegionView />}
+            {view === 'offer' && <OfferView />}
+            {view === 'channel' && <ChannelView />}
+            {view === 'all' && (
+              <div className="side-by-side">
+                <div>
+                  <h3>High Level Campaign Metrics</h3>
+                  <GlobalView />
+                </div>
+                <div>
+                  <h3>By Region</h3>
+                  <RegionView />
+                </div>
+                {results.offerBreakdown && (
+                  <div>
+                    <h3>By Offer Type</h3>
+                    <OfferView />
+                  </div>
+                )}
+                {results.channelBreakdown && (
+                  <div>
+                    <h3>By Channel</h3>
+                    <ChannelView />
+                  </div>
+                )}
+              </div>
+            )}
 
-      <h1 style={{ fontSize: '2.5rem' }}>Welcome to TRC SalesGPT</h1>
-      <button onClick={handleConnect}>Connect Microsoft</button>
-    </div>
+            <h3>Monthly Projection</h3>
+            <table className="monthly-table">
+              <thead>
+                <tr>
+                  <th></th>
+                  {results.monthly.map((_, i) => (
+                    <th key={i}>{`Month ${i + 1}`}</th>
+                  ))}
+                  <th>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(() => {
+                  const makeRow = (label, arr, formatter) => {
+                    const total = arr.reduce((a, b) => a + b, 0);
+                    return (
+                      <tr>
+                        <td>{label}</td>
+                        {arr.map((v, i) => (
+                          <td key={i}>{formatter(v)}</td>
+                        ))}
+                        <td>{formatter(total)}</td>
+                      </tr>
+                    );
+                  };
+                  return (
+                    <>
+                      {makeRow(
+                        'Orders',
+                        results.monthly.map((m) => m.orders),
+                        (v) => formatNumber(Math.round(v))
+                      )}
+                      {makeRow(
+                        'Revenue',
+                        results.monthly.map((m) => m.revenue),
+                        (v) => formatCurrency(v, results.currency)
+                      )}
+                      {makeRow(
+                        'Total Cashback',
+                        results.monthly.map((m) => m.cashback),
+                        (v) => formatCurrency(v, results.currency)
+                      )}
+                      {makeRow(
+                        'Net Revenue',
+                        results.monthly.map((m) => m.netRevenue),
+                        (v) => formatCurrency(v, results.currency)
+                      )}
+                    </>
+                  );
+                })()}
+              </tbody>
+            </table>
+            <p className="disclaimer">
+              All forecasts are based on historic sales data and can vary based on a
+              number of variables. These forecasts should not be used as an exact
+              budget but more as a gauge of the success of a campaign with The
+              Reward Collection. We're looking forward to advancing our
+              conversations. Thanks,{' '}
+              {rep.charAt(0).toUpperCase() + rep.slice(1)} ({rep}
+              @thewardcollection.com)
+            </p>
+            </div>
+          </div>
+        )}
+      </main>
+    </>
   );
 }

--- a/pages/publishers.js
+++ b/pages/publishers.js
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { usePublishers, DEFAULT_PUBLISHERS } from '../lib/usePublishers';
+
+export default function PublisherAdmin() {
+  const [publishers, setPublishers] = usePublishers();
+  const [editing, setEditing] = useState(null);
+  const [form, setForm] = useState({
+    network: '',
+    sub: '',
+    regions: 'UK',
+    reach: '',
+    newCustomers: false,
+  });
+
+  const resetForm = () => {
+    setEditing(null);
+    setForm({ network: '', sub: '', regions: 'UK', reach: '', newCustomers: false });
+  };
+
+  const startEdit = (p) => {
+    setEditing(p.id);
+    setForm({
+      network: p.network,
+      sub: p.sub,
+      regions: p.regions.join(','),
+      reach: p.reach,
+      newCustomers: p.newCustomers,
+    });
+  };
+
+  const savePublisher = (e) => {
+    e.preventDefault();
+    const regions = form.regions.split(',').map((r) => r.trim().toUpperCase());
+    const updated = { ...form, regions, reach: parseInt(form.reach, 10) || 0, id: editing ?? Date.now() };
+    setPublishers((prev) => {
+      if (editing) {
+        return prev.map((p) => (p.id === editing ? updated : p));
+      }
+      return [...prev, updated];
+    });
+    resetForm();
+  };
+
+  const removePublisher = (id) => {
+    if (confirm('Delete publisher?')) {
+      setPublishers((prev) => prev.filter((p) => p.id !== id));
+    }
+  };
+
+  const restoreDefaults = () => {
+    if (confirm('Restore default data?')) {
+      setPublishers(DEFAULT_PUBLISHERS);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Publisher Data</title>
+      </Head>
+      <main className="container">
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Link href="/">Back</Link>
+          <button type="button" onClick={restoreDefaults}>Restore Defaults</button>
+        </div>
+        <h1>Publishers</h1>
+        <table className="monthly-table">
+          <thead>
+            <tr>
+              <th>Network</th>
+              <th>Sub Publishers</th>
+              <th>Regions</th>
+              <th>Reach</th>
+              <th>New Customers</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {publishers.map((p) => (
+              <tr key={p.id}>
+                <td>{p.network}</td>
+                <td>{p.sub}</td>
+                <td>{p.regions.join(', ')}</td>
+                <td>{p.reach.toLocaleString()}</td>
+                <td>{p.newCustomers ? 'Yes' : 'No'}</td>
+                <td>
+                  <button type="button" onClick={() => startEdit(p)}>Edit</button>{' '}
+                  <button type="button" onClick={() => removePublisher(p.id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <form onSubmit={savePublisher} className="form" style={{ marginTop: '20px' }}>
+          <h3>{editing ? 'Edit Publisher' : 'Add Publisher'}</h3>
+          <label className="full-width">
+            Network
+            <input value={form.network} onChange={(e) => setForm({ ...form, network: e.target.value })} required />
+          </label>
+          <label className="full-width">
+            Sub Publishers
+            <input value={form.sub} onChange={(e) => setForm({ ...form, sub: e.target.value })} required />
+          </label>
+          <label>
+            Regions (comma separated e.g. UK,US)
+            <input value={form.regions} onChange={(e) => setForm({ ...form, regions: e.target.value })} />
+          </label>
+          <label>
+            Reach
+            <input type="number" value={form.reach} onChange={(e) => setForm({ ...form, reach: e.target.value })} />
+          </label>
+          <label className="checkbox">
+            <input type="checkbox" checked={form.newCustomers} onChange={(e) => setForm({ ...form, newCustomers: e.target.checked })} /> New Customers
+          </label>
+          <button type="submit" className="full-width">{editing ? 'Save' : 'Add'}</button>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,14 +1,41 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
+:root {
+  /* TRC brand blue */
+  --brand: #005eb8;
+  --bg: #0b0b0e;
+  --text: #e4e4e4;
+  --panel-bg: #121214;
+  --input-bg: #1c1c1f;
+  --border-color: #333;
+}
+
+[data-theme='light'] {
+  --bg: #ffffff;
+  --text: #111111;
+  --panel-bg: #f5f5f5;
+  --input-bg: #ffffff;
+  --border-color: #cccccc;
+}
 
 body {
-  background-color: #0c0c0f;
-  color: white;
-  font-family: 'Arial', sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
 }
 
+a {
+  color: var(--brand);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
 button {
-  background-color: #007bff;
+  background-color: var(--brand);
   border: none;
   padding: 12px 24px;
   border-radius: 8px;
@@ -16,8 +43,194 @@ button {
   cursor: pointer;
   color: white;
   margin-top: 20px;
+  transition: background-color 0.2s ease, transform 0.1s ease;
 }
 
 button:hover {
-  background-color: #0056b3;
+  background-color: #5a0145;
+  transform: translateY(-2px);
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 50px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+}
+
+form.form {
+  background: var(--panel-bg);
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.6);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+h1 {
+  text-align: center;
+  color: var(--brand);
+}
+
+.region-group {
+  margin-bottom: 16px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  border: 1px solid var(--border-color);
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.region-group legend {
+  padding: 0 6px;
+  color: var(--brand);
+}
+
+form.form label {
+  display: block;
+  margin-bottom: 16px;
+}
+
+form.form input,
+form.form select {
+  width: 100%;
+  padding: 10px;
+  margin-top: 4px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text);
+}
+
+form.form input[type='checkbox'] {
+  width: auto;
+  accent-color: var(--brand);
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.checkbox-row {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+
+form.form label.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.results {
+  margin-top: 30px;
+  background: var(--panel-bg);
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+.results h2 {
+  margin-top: 0;
+  color: var(--brand);
+}
+
+.results h3 {
+  color: var(--brand);
+}
+
+.reach-input {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.view-toggle {
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.view-toggle button {
+  margin-top: 0;
+  margin-left: 10px;
+}
+
+.results table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+.results th,
+.results td {
+  border: 1px solid var(--border-color);
+  padding: 12px;
+}
+
+.results table {
+  font-size: 1.1rem;
+}
+
+.monthly-table {
+  font-size: 1.3rem;
+}
+
+.totals-row {
+  font-weight: 600;
+  background: var(--input-bg);
+}
+
+
+
+.theme-switch {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+
+.theme-switch button {
+  margin-top: 0;
+}
+
+.side-by-side {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+}
+
+.side-by-side > * {
+  width: 100%;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 8px;
+  border: 1px solid var(--border-color);
+}
+
+.disclaimer {
+  margin-top: 20px;
+  font-size: 0.9rem;
+  line-height: 1.4;
 }


### PR DESCRIPTION
## Summary
- add Sales Rep dropdown to select a rep when creating a forecast
- exclude view controls from PDF capture and append a disclaimer
- style the new disclaimer text
- document sales rep selection and cleaner PDF output

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d19d613cc8320a7265718b411ce02