### PR TITLE
Fix saved forecast links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # TRC SalesGPT Frontend
 
-This is the frontend for TRC SalesGPT. To connect Microsoft, click the button on the homepage.
+This project contains a small Next.js frontend for the TRC SalesGPT demo.
+
+## Getting started
+
+1. Run `npm install` to install dependencies.
+2. Use `npm run dev` to start the development server or `npm run build` to build for production.
+
+## Features
+
+- **Forecasting tool** – The homepage hosts **The Reward Collection Forecasting Tool**. Select the sales rep, choose multiple regions and tier, pick a starting month, and enter cashback rates. Tick **In-store Offer** if the campaign includes stores. Reach for each region auto-fills from publisher data and is halved to reflect realistic campaign performance. When a campaign is new‑customer only, reach is first limited to publishers that support new customers before the 50% reduction. Results include a six-month growth curve with tables showing revenue, total cashback, **net revenue** and sales, and the month headers reflect the chosen start month. Currency is chosen automatically (GBP for UK, USD for US, EUR for EU or whichever region contributes the most sales). The results heading displays the retailer name followed by "6-Month Forecast". The interface loads in light mode by default, with a toggle at the top right to switch to dark mode. A **Download PDF** button saves the forecast without the view controls and includes a note from the chosen sales rep. When an in-store offer is provided, another table splits results by channel and appears in the **View All** display.
+- Adjust month-by-month totals using sliders beneath each month header. Moving a slider up or down redistributes spend across the remaining months so the six-month total stays the same.
+- High level metrics include a fixed **28% increase in basket spend** row alongside orders, revenue, cashback, net revenue and ROAS. The campaign metrics also list the cashback percentage used (or separate existing and new rates if tactical).
+- **Publisher manager** – Use the Publishers link to view, add or edit publisher entries that feed the automated reach numbers.
+- **Publisher forecasts** – Use the Publisher Forecasts page to enter real transaction count and revenue figures from partners. Tick **In-store Offer** to provide separate in‑store counts and revenue. Cashback is entered as a percentage so totals are calculated automatically. Results include AOV and ROAS and can cover a 3‑ or 6‑month period in any currency. The results dropdown lets you view totals by offer type or by channel, and the high level metrics list the cashback amounts **and the rates** for existing and new customers.
+- **Saved forecasts** – After calculating results you can save the current forecast. Visit the Saved Forecasts page from the top bar to review or delete stored forecasts.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ The tool sums the reach for the selected regions and applies a conversion rate b
 ```
 
 Expected orders, revenue, total cashback and ROAS are displayed along with the appropriate currency symbol.
+
+Saved forecasts are stored in a Supabase table so the sales team can revisit results later.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 # TRC SalesGPT Frontend
 
-This project contains a small Next.js frontend for the TRC SalesGPT demo.
+This is a small Next.js app that lets the sales team quickly estimate results for a cashback campaign.
 
 ## Getting started
 
 1. Run `npm install` to install dependencies.
-2. Use `npm run dev` to start the development server or `npm run build` to build for production.
+2. Start the development server with `npm run dev`.
 
-## Features
+## Forecasting GPT
 
-- **Forecasting tool** – The homepage hosts **The Reward Collection Forecasting Tool**. Select the sales rep, choose multiple regions and tier, pick a starting month, and enter cashback rates. Tick **In-store Offer** if the campaign includes stores. Reach for each region auto-fills from publisher data and is halved to reflect realistic campaign performance. When a campaign is new‑customer only, reach is first limited to publishers that support new customers before the 50% reduction. Results include a six-month growth curve with tables showing revenue, total cashback, **net revenue** and sales, and the month headers reflect the chosen start month. Currency is chosen automatically (GBP for UK, USD for US, EUR for EU or whichever region contributes the most sales). The results heading displays the retailer name followed by "6-Month Forecast". The interface loads in light mode by default, with a toggle at the top right to switch to dark mode. A **Download PDF** button saves the forecast without the view controls and includes a note from the chosen sales rep. When an in-store offer is provided, another table splits results by channel and appears in the **View All** display.
-- Adjust month-by-month totals using sliders beneath each month header. Moving a slider up or down redistributes spend across the remaining months so the six-month total stays the same.
-- High level metrics include a fixed **28% increase in basket spend** row alongside orders, revenue, cashback, net revenue and ROAS. The campaign metrics also list the cashback percentage used (or separate existing and new rates if tactical).
-- **Publisher manager** – Use the Publishers link to view, add or edit publisher entries that feed the automated reach numbers.
-- **Publisher forecasts** – Use the Publisher Forecasts page to enter real transaction count and revenue figures from partners. Tick **In-store Offer** to provide separate in‑store counts and revenue. Cashback is entered as a percentage so totals are calculated automatically. Results include AOV and ROAS and can cover a 3‑ or 6‑month period in any currency. The results dropdown lets you view totals by offer type or by channel, and the high level metrics list the cashback amounts **and the rates** for existing and new customers.
-- **Saved forecasts** – After calculating results you can save the current forecast. Visit the Saved Forecasts page from the top bar to review or delete stored forecasts.
+Open the site and enter:
+
+- **Retailer Name**
+- **Tier** (1–3)
+- **Average Order Value**
+- **Regions** where the campaign will run (UK, US, EU)
+- **% Cashback** offered
+
+The tool sums the reach for the selected regions and applies a conversion rate based on the tier:
+
+```
+1 → 0.1%
+2 → 0.05%
+3 → 0.025%
+```
+
+Expected orders, revenue, total cashback and ROAS are displayed along with the appropriate currency symbol.

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  'https://hwglmudfkjctsdnyutsp.supabase.co',
+  'sb_publishable_6QmEr0Ld38M6wifYKn3X_Q_eDJaDypn'
+);

--- a/lib/usePublishers.js
+++ b/lib/usePublishers.js
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+
+export const DEFAULT_PUBLISHERS = [
+  { id: 1, network: 'Loyalty Key', sub: 'Visa B2C, Loyalty Key', regions: ['EU'], reach: 300000, newCustomers: true },
+  { id: 2, network: 'LUX', sub: 'Revolut', regions: ['EU'], reach: 18000000, newCustomers: false },
+  { id: 3, network: 'Pluxee', sub: 'Spreecard, Airtime, SuitsMe Card, Anna Money', regions: ['UK'], reach: 3500000, newCustomers: false },
+  { id: 4, network: 'LUX', sub: 'Mastercard B2B', regions: ['UK'], reach: 3600000, newCustomers: false },
+  { id: 5, network: 'LUX', sub: 'Revolut', regions: ['UK'], reach: 9000000, newCustomers: false },
+  { id: 6, network: 'LUX', sub: 'Hyperjar', regions: ['UK'], reach: 600000, newCustomers: false },
+  { id: 7, network: 'LUX', sub: 'Boogi: Capital On Tap, Give As You Live', regions: ['UK'], reach: 565000, newCustomers: true },
+  { id: 9, network: 'Fidel', sub: 'Tenerity, Weselyan, Squaremeal, Next Jump, Topcashback, Complete Savings, Zilch', regions: ['UK'], reach: 1100000, newCustomers: false },
+  { id:10, network: 'Collinson', sub: 'British Airways, Aerlingus', regions: ['UK'], reach: 1000000, newCustomers: false },
+  { id:11, network: 'Collinson', sub: 'Tide Bank', regions: ['UK'], reach: 690000, newCustomers: true },
+  { id:12, network: 'Curve', sub: 'Curve', regions: ['UK'], reach: 400000, newCustomers: false },
+  { id:13, network: 'Pockit Ltd', sub: 'Pockit', regions: ['UK'], reach: 900000, newCustomers: false },
+  { id:14, network: 'Railsr', sub: 'Pay IO (B2B)', regions: ['UK'], reach: 2000000, newCustomers: false },
+  { id:15, network: 'LUX', sub: 'Mastercard B2B', regions: ['US'], reach: 17000000, newCustomers: false },
+  { id:16, network: 'LUX', sub: 'Revolut', regions: ['US'], reach: 1000000, newCustomers: false },
+  { id:17, network: 'Collinson', sub: 'JetBlue, Emirates, NCR, American Airlines, Simply Miles, Flying Blue, Virgin', regions: ['US'], reach: 16000000, newCustomers: true },
+  { id:18, network: 'Fidel USA', sub: 'Dolr, Percents, Viffy', regions: ['US'], reach: 100000, newCustomers: false },
+  { id:19, network: 'Fidel USA', sub: 'Cashapp', regions: ['US'], reach: 88000000, newCustomers: true },
+  { id:20, network: 'Fidel USA', sub: 'PNC', regions: ['US'], reach: 9000000, newCustomers: true },
+  { id:21, network: 'Fidel USA', sub: 'Bank Of America', regions: ['US'], reach: 50000000, newCustomers: true },
+  { id:22, network: 'Fidel USA', sub: 'Visa B2B', regions: ['US'], reach: 1200000, newCustomers: false },
+  { id:23, network: 'Fidel USA', sub: 'American Express', regions: ['US'], reach: 70000000, newCustomers: true },
+  { id:24, network: 'Fidel USA', sub: 'Barclays', regions: ['US'], reach: 8000000, newCustomers: true },
+  { id:25, network: 'Fidel USA', sub: 'Citadel Credit Union', regions: ['US'], reach: 100000, newCustomers: true },
+  { id:26, network: 'Fidel USA', sub: 'Citizens Bank', regions: ['US'], reach: 4000000, newCustomers: true },
+  { id:27, network: 'Olive', sub: 'NCAA, American Cancer Society, YouthSport, WorldVision, Shop.com, QuestTrade, Price.com', regions: ['US'], reach: 500000, newCustomers: false },
+  { id:28, network: 'Drop', sub: 'Acorns', regions: ['US'], reach: 10000000, newCustomers: true },
+  { id:29, network: 'Drop', sub: 'AFS (Affinity Financial Solutions)', regions: ['US'], reach: 17000000, newCustomers: true },
+];
+
+export function usePublishers() {
+  const [publishers, setPublishers] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('publishers');
+    if (stored) {
+      try {
+        setPublishers(JSON.parse(stored));
+        return;
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    setPublishers(DEFAULT_PUBLISHERS);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('publishers', JSON.stringify(publishers));
+  }, [publishers]);
+
+  return [publishers, setPublishers];
+}
+
+export function computeReach(publishers, region, includeNew) {
+  return publishers
+    .filter((p) => p.regions.includes(region) && (!includeNew || p.newCustomers))
+    .reduce((sum, p) => sum + p.reach, 0);
+}

--- a/lib/useSavedForecasts.js
+++ b/lib/useSavedForecasts.js
@@ -1,29 +1,50 @@
 import { useState, useEffect } from 'react';
+import { supabase } from './supabaseClient';
 
 export function useSavedForecasts() {
-  const [forecasts, setForecasts] = useState([]);
+  const [forecasts, setForecasts] = useState(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem('savedForecasts');
-    if (stored) {
-      try {
-        setForecasts(JSON.parse(stored));
-      } catch (e) {
-        console.error(e);
+    async function load() {
+      const { data, error } = await supabase
+        .from('forecasts')
+        .select('*')
+        .order('id', { ascending: false });
+      if (!error) {
+        setForecasts(
+          (data || []).map((row) => ({
+            id: row.id,
+            savedAt: row.created_at,
+            ...row.data,
+          }))
+        );
+      } else {
+        console.error(error);
+        setForecasts([]);
       }
     }
+    load();
   }, []);
 
-  useEffect(() => {
-    localStorage.setItem('savedForecasts', JSON.stringify(forecasts));
-  }, [forecasts]);
-
-  const addForecast = (data) => {
-    setForecasts((prev) => [...prev, { id: Date.now(), savedAt: Date.now(), ...data }]);
+  const addForecast = async (data) => {
+    const { data: inserted, error } = await supabase
+      .from('forecasts')
+      .insert([{ data }])
+      .select()
+      .single();
+    if (!error && inserted) {
+      setForecasts((prev) => [
+        ...(prev || []),
+        { id: inserted.id, savedAt: inserted.created_at, ...data },
+      ]);
+    }
   };
 
-  const removeForecast = (id) => {
-    setForecasts((prev) => prev.filter((f) => f.id !== id));
+  const removeForecast = async (id) => {
+    const { error } = await supabase.from('forecasts').delete().eq('id', id);
+    if (!error) {
+      setForecasts((prev) => (prev || []).filter((f) => f.id !== id));
+    }
   };
 
   return [forecasts, addForecast, removeForecast];

--- a/lib/useSavedForecasts.js
+++ b/lib/useSavedForecasts.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+export function useSavedForecasts() {
+  const [forecasts, setForecasts] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('savedForecasts');
+    if (stored) {
+      try {
+        setForecasts(JSON.parse(stored));
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('savedForecasts', JSON.stringify(forecasts));
+  }, [forecasts]);
+
+  const addForecast = (data) => {
+    setForecasts((prev) => [...prev, { id: Date.now(), savedAt: Date.now(), ...data }]);
+  };
+
+  const removeForecast = (id) => {
+    setForecasts((prev) => prev.filter((f) => f.id !== id));
+  };
+
+  return [forecasts, addForecast, removeForecast];
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "latest",
     "react-dom": "latest",
     "html2canvas": "^1.4.1",
-    "jspdf": "^2.5.1"
+    "jspdf": "^2.5.1",
+    "@supabase/supabase-js": "^2.39.1"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,4 @@
+import '../styles/globals.css';
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,17 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html data-theme="light">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,870 +1,136 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import Head from 'next/head';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { usePublishers, computeReach } from '../lib/usePublishers';
-import { useSavedForecasts } from '../lib/useSavedForecasts';
-import html2canvas from 'html2canvas';
-import jsPDF from 'jspdf';
 
-const REGIONS = ['UK', 'US', 'EU'];
-const SALES_REPS = ['james', 'lucy', 'rebecca', 'ryan', 'preena', 'shamas', 'shaun'];
-const MONTHS = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
-const MONTH_CHANGES = {
-  January: -0.2,
-  February: 0.05,
-  March: 0.05,
-  April: 0.07,
-  May: -0.02,
-  June: 0.03,
-  July: 0.06,
-  August: 0.08,
-  September: 0.04,
-  October: 0.05,
-  November: 0.1,
-  December: 0.1,
+const REGIONS = {
+  UK: { reach: 5000000, currency: 'GBP' },
+  US: { reach: 10000000, currency: 'USD' },
+  EU: { reach: 8000000, currency: 'EUR' },
 };
 
-// Conversion rates by tier. Reduced by 50% from the previous values so
-// forecasts are more conservative.
-const CONVERSION_BY_TIER = {
-  1: 0.0005,
-  2: 0.00025,
-  3: 0.000125,
-  4: 0.0000625,
-  5: 0.0000425,
-  6: 0.000025,
-};
-
-const MONTH_DELTAS = [0, 0.05, 0.07, -0.02, 0.06, 0.04];
-
-
-const NUM_FORMAT = new Intl.NumberFormat('en-US');
+const CONVERSION = { 1: 0.001, 2: 0.0005, 3: 0.00025 };
 
 function formatNumber(n) {
-  return NUM_FORMAT.format(Number(n || 0));
+  return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
 }
-
-const REGION_CURRENCIES = {
-  UK: 'GBP',
-  US: 'USD',
-  EU: 'EUR',
-};
-
-const CURRENCY_SYMBOLS = {
-  GBP: '£',
-  USD: '$',
-  EUR: '€',
-};
 
 function formatCurrency(n, code) {
-  const symbol = CURRENCY_SYMBOLS[code] || '';
+  const symbols = { GBP: '£', USD: '$', EUR: '€' };
   return (
-    symbol +
-    n.toLocaleString(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    })
+    symbols[code] +
+    n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
   );
 }
 
-function computeMonthlyShares(baseShares, weights) {
-  const adjusted = baseShares.map((s, i) => s * (weights[i] || 1));
-  const sum = adjusted.reduce((a, b) => a + b, 0) || 1;
-  return adjusted.map((s) => s / sum);
-}
-
-
-export default function Forecast() {
+export default function Home() {
   const [retailer, setRetailer] = useState('');
-  const [rep, setRep] = useState(SALES_REPS[0]);
-  const [regions, setRegions] = useState([]);
   const [tier, setTier] = useState('1');
-  const [online, setOnline] = useState(false);
-  const [instore, setInstore] = useState(false);
-  const [stores, setStores] = useState('');
+  const [regions, setRegions] = useState([]);
   const [aov, setAov] = useState('');
-  const [reach, setReach] = useState({});
-  const [publishers] = usePublishers();
-  const [cashbackExisting, setCashbackExisting] = useState('');
-  const [cashbackNew, setCashbackNew] = useState('');
-  const [results, setResults] = useState(null);
-  const [view, setView] = useState('global');
-  const [startMonth, setStartMonth] = useState(MONTHS[0]);
-  const [theme, setTheme] = useState('light');
-  const [baseShares, setBaseShares] = useState([]);
-  const [weights, setWeights] = useState(Array(6).fill(1));
-  const resultsRef = useRef(null);
-  const [forecasts, addSavedForecast] = useSavedForecasts();
-  const router = useRouter();
+  const [cashback, setCashback] = useState('');
+  const [result, setResult] = useState(null);
 
-  useEffect(() => {
-    if (!router.query.edit || forecasts.length === 0) return;
-    const f = forecasts.find((fc) => fc.id === Number(router.query.edit));
-    if (f && f.inputs) {
-      const inp = f.inputs;
-      setRetailer(inp.retailer || '');
-      setRep(inp.rep || SALES_REPS[0]);
-      setRegions(inp.regions || []);
-      setTier(String(inp.tier || '1'));
-      setOnline(!!inp.online);
-      setInstore(!!inp.instore);
-      setStores(inp.stores || '');
-      setAov(inp.aov || '');
-      setCashbackExisting(inp.cashbackExisting || '');
-      setCashbackNew(inp.cashbackNew || '');
-      setStartMonth(inp.startMonth || MONTHS[0]);
-      setReach(inp.reach || {});
-      if (f.results) setResults(f.results);
-    }
-  }, [router.query.edit, forecasts]);
-
-  useEffect(() => {
-    document.documentElement.dataset.theme = theme;
-  }, [theme]);
-
-  useEffect(() => {
-    const newOnly =
-      parseFloat(cashbackNew) > 0 && (!cashbackExisting || parseFloat(cashbackExisting) === 0);
-    const obj = {};
-    regions.forEach((r) => {
-      const baseReach = computeReach(publishers, r, newOnly);
-      obj[r] = Math.round(baseReach * 0.5);
-    });
-    setReach(obj);
-  }, [regions, cashbackExisting, cashbackNew, publishers]);
-
-  useEffect(() => {
-    if (!results || baseShares.length === 0) return;
-    const aovNum = parseFloat(aov) || 0;
-    const existingCb = parseFloat(cashbackExisting) || 0;
-    const newCb = parseFloat(cashbackNew) || 0;
-    const hasExisting = existingCb > 0;
-    const hasNew = newCb > 0;
-    const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
-    const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
-    const shares = computeMonthlyShares(baseShares, weights);
-    const monthly = shares.map((s) => {
-      const monthOrders = results.total.orders * s;
-      const monthRevenue = monthOrders * aovNum;
-      const monthCashback =
-        monthOrders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
-      return {
-        orders: monthOrders,
-        revenue: monthRevenue,
-        cashback: monthCashback,
-        netRevenue: monthRevenue - monthCashback,
-      };
-    });
-    setResults((prev) => ({ ...prev, monthly }));
-  }, [weights]);
-
-  const GlobalView = () => (
-    <table className="summary-table">
-      <tbody>
-        <tr>
-          <th>Expected Orders</th>
-          <td>{formatNumber(Math.round(results.total.orders))}</td>
-        </tr>
-        <tr>
-          <th>Revenue</th>
-          <td>
-            {formatCurrency(results.total.revenue, results.currency)}
-          </td>
-        </tr>
-        <tr>
-          <th>Total Cashback</th>
-          <td>
-            {formatCurrency(results.total.cashback, results.currency)}
-          </td>
-        </tr>
-        {(() => {
-          const ex = results.cashbackRates?.existing || 0;
-          const nw = results.cashbackRates?.new || 0;
-          if (ex > 0 && nw > 0) {
-            return (
-              <>
-                <tr>
-                  <th>New Customer Total Cashback</th>
-                  <td>{nw}%</td>
-                </tr>
-                <tr>
-                  <th>Existing Customer Total Cashback</th>
-                  <td>{ex}%</td>
-                </tr>
-              </>
-            );
-          }
-          const rate = ex > 0 ? ex : nw;
-          return rate ? (
-            <tr>
-              <th>Total Cashback</th>
-              <td>{rate}%</td>
-            </tr>
-          ) : null;
-        })()}
-        <tr>
-          <th>Net Revenue</th>
-          <td>
-            {formatCurrency(results.total.netRevenue, results.currency)}
-          </td>
-        </tr>
-        <tr>
-          <th>Increase in Basket Spend</th>
-          <td>28%</td>
-        </tr>
-        <tr>
-          <th>ROAS</th>
-          <td>{results.total.roas.toFixed(2)}x</td>
-        </tr>
-      </tbody>
-    </table>
-  );
-
-  const RegionView = () => (
-    <table className="monthly-table">
-      <thead>
-        <tr>
-          <th>Region</th>
-          <th>Orders</th>
-          <th>Revenue</th>
-          <th>Total Cashback</th>
-          <th>Net Revenue</th>
-        </tr>
-      </thead>
-      <tbody>
-        {Object.entries(results.perRegion).map(([r, d]) => (
-          <tr key={r}>
-            <td>
-              {r} ({CURRENCY_SYMBOLS[REGION_CURRENCIES[r]]})
-            </td>
-            <td>{formatNumber(Math.round(d.orders))}</td>
-            <td>{formatCurrency(d.revenue, REGION_CURRENCIES[r])}</td>
-            <td>{formatCurrency(d.cashback, REGION_CURRENCIES[r])}</td>
-            <td>{formatCurrency(d.netRevenue, REGION_CURRENCIES[r])}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-
-  const OfferView = () => (
-    results.offerBreakdown && (
-      <table className="monthly-table">
-        <thead>
-          <tr>
-            <th>Type</th>
-            <th>Orders</th>
-            <th>Revenue</th>
-            <th>Total Cashback</th>
-            <th>Net Revenue</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.entries(results.offerBreakdown).map(([t, d]) => (
-            <tr key={t}>
-              <td>{t}</td>
-              <td>{formatNumber(Math.round(d.orders))}</td>
-              <td>{formatCurrency(d.revenue, results.currency)}</td>
-              <td>{formatCurrency(d.cashback, results.currency)}</td>
-              <td>{formatCurrency(d.netRevenue, results.currency)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    )
-  );
-
-  const ChannelView = () => (
-    results.channelBreakdown && (
-      <table className="monthly-table">
-        <thead>
-          <tr>
-            <th>Channel</th>
-            <th>Orders</th>
-            <th>Revenue</th>
-            <th>Total Cashback</th>
-            <th>Net Revenue</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.entries(results.channelBreakdown).map(([c, d]) => (
-            <tr key={c}>
-              <td>{c}</td>
-              <td>{formatNumber(Math.round(d.orders))}</td>
-              <td>{formatCurrency(d.revenue, results.currency)}</td>
-              <td>{formatCurrency(d.cashback, results.currency)}</td>
-              <td>{formatCurrency(d.netRevenue, results.currency)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    )
-  );
-
-
-  const toggleRegion = (region) => {
-    setRegions((prev) => {
-      if (prev.includes(region)) {
-        const updated = prev.filter((r) => r !== region);
-        setReach((curr) => {
-          const copy = { ...curr };
-          delete copy[region];
-          return copy;
-        });
-        return updated;
-      }
-      setReach((curr) => ({ ...curr, [region]: '' }));
-      return [...prev, region];
-    });
-  };
-
-  const updateWeight = (index, value) => {
-    setWeights((prev) => {
-      const next = [...prev];
-      next[index] = value;
-      return next;
-    });
+  const toggleRegion = (r) => {
+    setRegions((prev) =>
+      prev.includes(r) ? prev.filter((x) => x !== r) : [...prev, r]
+    );
   };
 
   const calculate = (e) => {
     e.preventDefault();
-
-    const storeCount = parseInt(stores, 10) || 0;
-    const baseConversion = CONVERSION_BY_TIER[tier] || 0;
-    const storeUplift = instore && storeCount > 0 ? storeCount * 0.000001 : 0;
-    const conversion = baseConversion + storeUplift;
-
-    const aovNum = parseFloat(aov) || 0;
-    const existingCb = parseFloat(cashbackExisting) || 0;
-    const newCb = parseFloat(cashbackNew) || 0;
-
-    const perRegion = {};
-    let totalOrders = 0;
-    let onlineOrdersTotal = 0;
-    let instoreOrdersTotal = 0;
-    regions.forEach((r) => {
-      const regionReach = parseInt(reach[r], 10) || 0;
-      let onlineOrders = 0;
-      let instoreOrders = 0;
-      if (online && instore) {
-        onlineOrders = regionReach * baseConversion;
-        instoreOrders = regionReach * storeUplift;
-      } else if (instore && !online) {
-        instoreOrders = regionReach * conversion;
-      } else {
-        onlineOrders = regionReach * baseConversion;
-      }
-      const orders = onlineOrders + instoreOrders;
-      perRegion[r] = { orders };
-      totalOrders += orders;
-      onlineOrdersTotal += onlineOrders;
-      instoreOrdersTotal += instoreOrders;
-    });
-
-    let existingOrders = 0;
-    let newOrders = 0;
-
-    const hasExisting = existingCb > 0;
-    const hasNew = newCb > 0;
-
-    const computeAmounts = (orders) => {
-      const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
-      const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
-      const revenue = orders * aovNum;
-      const cashback =
-        orders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
-      return {
-        orders,
-        revenue,
-        cashback,
-        netRevenue: revenue - cashback,
-      };
-    };
-
-    if (hasExisting && hasNew) {
-      existingOrders = totalOrders * 0.6;
-      newOrders = totalOrders * 0.4;
-    } else if (hasNew && !hasExisting) {
-      newOrders = totalOrders * 0.4;
-      totalOrders = newOrders;
-    } else {
-      existingOrders = totalOrders;
-    }
-
-    const channelBreakdown =
-      online && instore
-        ? {
-            online: computeAmounts(onlineOrdersTotal),
-            instore: computeAmounts(instoreOrdersTotal),
-          }
-        : null;
-
-    const { revenue, cashback: cashbackAmount, netRevenue } =
-      computeAmounts(totalOrders);
-    const roas = cashbackAmount ? revenue / cashbackAmount : 0;
-
-    Object.keys(perRegion).forEach((r) => {
-      const orders = perRegion[r].orders;
-      let ex = 0;
-      let nw = 0;
-      if (hasExisting && hasNew) {
-        ex = orders * 0.6;
-        nw = orders * 0.4;
-      } else if (hasNew && !hasExisting) {
-        nw = orders * 0.4;
-      } else {
-        ex = orders;
-      }
-      const rev = orders * aovNum;
-      const cashbackAmount =
-        ex * aovNum * (existingCb / 100) + nw * aovNum * (newCb / 100);
-      perRegion[r] = {
-        orders,
-        revenue: rev,
-        cashback: cashbackAmount,
-        netRevenue: rev - cashbackAmount,
-      };
-    });
-
-    const startIndex = MONTHS.indexOf(startMonth);
-    const monthLabels = [];
-    const deltas = [];
-    for (let i = 0; i < 6; i++) {
-      const idx = (startIndex + i) % MONTHS.length;
-      const m = MONTHS[idx];
-      monthLabels.push(m);
-      deltas.push(MONTH_CHANGES[m] || 0);
-    }
-
-    const factors = [];
-    factors[0] = 1 + deltas[0];
-    for (let i = 1; i < 6; i++) {
-      factors[i] = factors[i - 1] * (1 + deltas[i]);
-    }
-    const sumFactors = factors.reduce((a, b) => a + b, 0);
-    const shares = factors.map((f) => f / sumFactors);
-    setBaseShares(shares);
-    setWeights(Array(6).fill(1));
-    const adjShares = computeMonthlyShares(shares, Array(6).fill(1));
-    const monthly = adjShares.map((s) => {
-      const monthOrders = totalOrders * s;
-      const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
-      const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
-      const monthRevenue = monthOrders * aovNum;
-      const monthCashback =
-        monthOrders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
-      return {
-        orders: monthOrders,
-        revenue: monthRevenue,
-        cashback: monthCashback,
-        netRevenue: monthRevenue - monthCashback,
-      };
-    });
-
-    const offerBreakdown =
-      hasExisting && hasNew
-        ? {
-            existing: {
-              orders: existingOrders,
-              revenue: existingOrders * aovNum,
-              cashback: existingOrders * aovNum * (existingCb / 100),
-              netRevenue:
-                existingOrders * aovNum -
-                existingOrders * aovNum * (existingCb / 100),
-            },
-            new: {
-              orders: newOrders,
-              revenue: newOrders * aovNum,
-              cashback: newOrders * aovNum * (newCb / 100),
-              netRevenue: newOrders * aovNum - newOrders * aovNum * (newCb / 100),
-            },
-          }
-        : null;
-
-    let bestRegion = regions[0];
-    let maxOrders = perRegion[bestRegion]?.orders || 0;
-    regions.forEach((r) => {
-      if ((perRegion[r]?.orders || 0) > maxOrders) {
-        bestRegion = r;
-        maxOrders = perRegion[r].orders;
-      }
-    });
-    const currency = REGION_CURRENCIES[bestRegion] || 'GBP';
-
-    setResults({
-      total: {
-        orders: totalOrders,
-        revenue,
-        cashback: cashbackAmount,
-        netRevenue,
-        roas,
-      },
-      perRegion,
-      monthly,
-      monthLabels,
-      offerBreakdown,
-      channelBreakdown,
-      currency,
-      cashbackRates: {
-        existing: existingCb,
-        new: newCb,
-      },
-    });
-  };
-
-  const downloadPdf = async () => {
-    if (!resultsRef.current) return;
-    const sliderRow = resultsRef.current.querySelector('.slider-row');
-    const viewToggle = resultsRef.current.querySelector('.view-toggle');
-    const prevSlider = sliderRow ? sliderRow.style.display : '';
-    const prevView = viewToggle ? viewToggle.style.display : '';
-    if (sliderRow) sliderRow.style.display = 'none';
-    if (viewToggle) viewToggle.style.display = 'none';
-    const canvas = await html2canvas(resultsRef.current);
-    if (sliderRow) sliderRow.style.display = prevSlider;
-    if (viewToggle) viewToggle.style.display = prevView;
-    const imgData = canvas.toDataURL('image/png');
-    const pdf = new jsPDF('p', 'mm', 'a4');
-    const pageWidth = pdf.internal.pageSize.getWidth();
-    const imgWidth = pageWidth;
-    const imgHeight = (canvas.height * imgWidth) / canvas.width;
-    let position = 0;
-    pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
-    let heightLeft = imgHeight - pdf.internal.pageSize.getHeight();
-    while (heightLeft > 0) {
-      position -= pdf.internal.pageSize.getHeight();
-      pdf.addPage();
-      pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
-      heightLeft -= pdf.internal.pageSize.getHeight();
-    }
-    const fileName = retailer ? `${retailer}-6-month-forecast.pdf` : '6-month-forecast.pdf';
-    pdf.save(fileName);
-  };
-
-  const saveForecast = () => {
-    if (!results) return;
-    addSavedForecast({
-      type: 'forecast',
-      retailer,
-      rep,
-      inputs: {
-        retailer,
-        rep,
-        regions,
-        tier,
-        online,
-        instore,
-        stores,
-        aov,
-        cashbackExisting,
-        cashbackNew,
-        startMonth,
-        reach,
-      },
-      results,
-    });
-    alert('Forecast saved');
+    if (regions.length === 0) return;
+    const reach = regions.reduce((sum, r) => sum + REGIONS[r].reach, 0);
+    const conv = CONVERSION[tier] || 0;
+    const orders = reach * conv;
+    const revenue = orders * (parseFloat(aov) || 0);
+    const cashbackCost = revenue * ((parseFloat(cashback) || 0) / 100);
+    const roas = cashbackCost ? revenue / cashbackCost : 0;
+    const mainCurrency = REGIONS[regions[0]].currency;
+    setResult({ reach, orders, revenue, cashbackCost, roas, currency: mainCurrency });
   };
 
   return (
-    <>
+    <div className="container">
       <Head>
-        <title>The Reward Collection Forecasting Tool</title>
+        <title>The Reward Collection Forecasting GPT</title>
       </Head>
-      <main className="container">
-        <div className="top-bar">
-          <div className="nav-links">
-            <Link href="/">Forecasting</Link>
-            <Link href="/publishers">Publishers</Link>
-            <Link href="/publisher-forecast">Publisher Forecasts</Link>
-            <Link href="/saved-forecasts">Saved Forecasts</Link>
-          </div>
-          <div className="theme-switch">
-            <button
-              type="button"
-              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            >
-              {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
-            </button>
-          </div>
+      <h1>The Reward Collection Forecasting GPT</h1>
+      <form onSubmit={calculate} className="form">
+        <label className="full-width">
+          Retailer Name
+          <input value={retailer} onChange={(e) => setRetailer(e.target.value)} required />
+        </label>
+        <label>
+          Tier
+          <select value={tier} onChange={(e) => setTier(e.target.value)}>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+          </select>
+        </label>
+        <label>
+          Average Order Value
+          <input
+            type="number"
+            value={aov}
+            onChange={(e) => setAov(e.target.value)}
+            required
+          />
+        </label>
+        <fieldset className="region-group full-width">
+          <legend>Regions</legend>
+          {Object.keys(REGIONS).map((r) => (
+            <label key={r} className="checkbox">
+              <input
+                type="checkbox"
+                checked={regions.includes(r)}
+                onChange={() => toggleRegion(r)}
+              />
+              {r}
+            </label>
+          ))}
+        </fieldset>
+        <label className="full-width">
+          % Cashback
+          <input
+            type="number"
+            value={cashback}
+            onChange={(e) => setCashback(e.target.value)}
+            required
+          />
+        </label>
+        <div className="full-width" style={{ textAlign: 'center' }}>
+          <button type="submit">Generate Forecast</button>
         </div>
-        <h1>The Reward Collection Forecasting Tool</h1>
-        <p style={{ textAlign: 'center' }}>
-          Enter campaign details below to estimate performance.
-        </p>
-          <form onSubmit={calculate} className="form">
-            <label className="full-width">
-              Sales Rep
-              <select value={rep} onChange={(e) => setRep(e.target.value)}>
-                {SALES_REPS.map((r) => (
-                  <option key={r} value={r}>
-                    {r.charAt(0).toUpperCase() + r.slice(1)}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="full-width">
-              Retailer Name
-              <input
-                type="text"
-                value={retailer}
-                onChange={(e) => setRetailer(e.target.value)}
-                required
-              />
-            </label>
-            <label className="full-width">
-              Starting Month
-              <select value={startMonth} onChange={(e) => setStartMonth(e.target.value)}>
-                {MONTHS.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <fieldset className="region-group full-width">
-              <legend>Regions</legend>
-              {REGIONS.map((r) => (
-                <label key={r} className="checkbox">
-                  <input
-                    type="checkbox"
-                  checked={regions.includes(r)}
-                  onChange={() => toggleRegion(r)}
-                />
-                {r}
-              </label>
-            ))}
-          </fieldset>
-            {regions.map((r) => (
-              <label key={`reach-${r}`} className="reach-input">
-                Reach {r}
-                <input
-                  type="text"
-                  value={reach[r] ? formatNumber(reach[r]) : ''}
-                  onChange={(e) =>
-                    setReach((curr) => ({
-                      ...curr,
-                      [r]:
-                        parseInt(e.target.value.replace(/[^0-9.]/g, ''), 10) || 0,
-                    }))
-                  }
-                />
-              </label>
-            ))}
-          <label>
-            Tier
-            <select value={tier} onChange={(e) => setTier(e.target.value)}>
-              {[1, 2, 3, 4, 5, 6].map((t) => (
-                <option key={t} value={t}>
-                  Tier {t}
-                </option>
-              ))}
-            </select>
-          </label>
-            <div className="checkbox-row">
-              <label className="checkbox">
-                <input
-                  type="checkbox"
-                  checked={online}
-                  onChange={(e) => setOnline(e.target.checked)}
-                />
-                Online
-              </label>
-              <label className="checkbox">
-                <input
-                  type="checkbox"
-                  checked={instore}
-                  onChange={(e) => setInstore(e.target.checked)}
-                />
-                In-store
-              </label>
-            </div>
-          {instore && (
-            <label>
-              Number of Stores
-              <input
-                type="number"
-                value={stores}
-                onChange={(e) => setStores(e.target.value)}
-                min="0"
-              />
-            </label>
-          )}
-          <label>
-            Average Order Value
-            <input
-              type="number"
-              value={aov}
-              onChange={(e) => setAov(e.target.value)}
-            />
-          </label>
-          <label>
-            Cashback Existing %
-            <input
-              type="number"
-              value={cashbackExisting}
-              onChange={(e) => setCashbackExisting(e.target.value)}
-            />
-          </label>
-          <label>
-            Cashback New %
-            <input
-              type="number"
-              value={cashbackNew}
-              onChange={(e) => setCashbackNew(e.target.value)}
-            />
-          </label>
-          <button type="submit" className="full-width">Calculate Forecast</button>
-        </form>
-        {results && (
-          <div className="results">
-            <div className="view-toggle">
-              <select value={view} onChange={(e) => setView(e.target.value)}>
-                <option value="global">High Level Campaign Metrics</option>
-                <option value="region">By Region</option>
-                {results.offerBreakdown && (
-                  <option value="offer">By Offer Type</option>
-                )}
-                {results.channelBreakdown && (
-                  <option value="channel">By Channel</option>
-                )}
-                <option value="all">View All</option>
-              </select>
-              <button type="button" onClick={downloadPdf}>Download PDF</button>
-            </div>
-            <div ref={resultsRef}>
-            <h2>{retailer ? `${retailer} 6-Month Forecast` : '6-Month Forecast'}</h2>
-            {view === 'global' && <GlobalView />}
-            {view === 'region' && <RegionView />}
-            {view === 'offer' && <OfferView />}
-            {view === 'channel' && <ChannelView />}
-            {view === 'all' && (
-              <div className="side-by-side">
-                <div>
-                  <h3>High Level Campaign Metrics</h3>
-                  <GlobalView />
-                </div>
-                <div>
-                  <h3>By Region</h3>
-                  <RegionView />
-                </div>
-                {results.offerBreakdown && (
-                  <div>
-                    <h3>By Offer Type</h3>
-                    <OfferView />
-                  </div>
-                )}
-                {results.channelBreakdown && (
-                  <div>
-                    <h3>By Channel</h3>
-                    <ChannelView />
-                  </div>
-                )}
-              </div>
-            )}
-
-            <h3>Monthly Projection</h3>
-            <table className="monthly-table">
-              <thead>
-                <tr>
-                  <th></th>
-                  {results.monthLabels.map((m, i) => (
-                    <th key={i}>{m}</th>
-                  ))}
-                  <th>Total</th>
-                </tr>
-                <tr className="slider-row">
-                  <th>Adjust</th>
-                  {weights.map((w, i) => (
-                    <th key={i}>
-                      <input
-                        type="range"
-                        min="0.5"
-                        max="1.5"
-                        step="0.01"
-                        value={w}
-                        onChange={(e) => updateWeight(i, parseFloat(e.target.value))}
-                      />
-                    </th>
-                  ))}
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {(() => {
-                  const makeRow = (label, arr, formatter) => {
-                    const total = arr.reduce((a, b) => a + b, 0);
-                    return (
-                      <tr>
-                        <td>{label}</td>
-                        {arr.map((v, i) => (
-                          <td key={i}>{formatter(v)}</td>
-                        ))}
-                        <td>{formatter(total)}</td>
-                      </tr>
-                    );
-                  };
-                  return (
-                    <>
-                      {makeRow(
-                        'Orders',
-                        results.monthly.map((m) => m.orders),
-                        (v) => formatNumber(Math.round(v))
-                      )}
-                      {makeRow(
-                        'Revenue',
-                        results.monthly.map((m) => m.revenue),
-                        (v) => formatCurrency(v, results.currency)
-                      )}
-                      {makeRow(
-                        'Total Cashback',
-                        results.monthly.map((m) => m.cashback),
-                        (v) => formatCurrency(v, results.currency)
-                      )}
-                      {makeRow(
-                        'Net Revenue',
-                        results.monthly.map((m) => m.netRevenue),
-                        (v) => formatCurrency(v, results.currency)
-                      )}
-                    </>
-                  );
-                })()}
-              </tbody>
-            </table>
-            <p className="disclaimer">
-              <strong>Disclaimer:</strong>
-              <br />
-              The projections outlined in this forecast are based on historical sales data and are influenced by a range of dynamic variables. While they offer a directional view of potential performance, they should not be considered fixed budgets or guaranteed outcomes. The Reward Collection provides these insights to help guide strategic planning and campaign alignment.
-              <br />
-              <br />
-              We look forward to continuing our discussions and exploring the opportunities ahead.
-              <br />
-              <br />
-              Warm regards,
-              <br />
-              {rep.charAt(0).toUpperCase() + rep.slice(1)}
-              <br />
-              {rep}@thewardcollection.com
-            </p>
-            <button type="button" onClick={saveForecast}>Save Forecast</button>
-            </div>
-          </div>
-        )}
-      </main>
-    </>
+      </form>
+      {result && (
+        <div className="results">
+          <h2>Forecast for {retailer}</h2>
+          <table>
+            <tbody>
+              <tr>
+                <th>Total Reach</th>
+                <td>{formatNumber(result.reach)}</td>
+              </tr>
+              <tr>
+                <th>Expected Orders</th>
+                <td>{formatNumber(result.orders)}</td>
+              </tr>
+              <tr>
+                <th>Revenue</th>
+                <td>{formatCurrency(result.revenue, result.currency)}</td>
+              </tr>
+              <tr>
+                <th>Total Cashback</th>
+                <td>{formatCurrency(result.cashbackCost, result.currency)}</td>
+              </tr>
+              <tr>
+                <th>ROAS</th>
+                <td>{result.roas.toFixed(2)}x</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -52,8 +52,10 @@ const CONVERSION_BY_TIER = {
 const MONTH_DELTAS = [0, 0.05, 0.07, -0.02, 0.06, 0.04];
 
 
+const NUM_FORMAT = new Intl.NumberFormat('en-US');
+
 function formatNumber(n) {
-  return n.toLocaleString();
+  return NUM_FORMAT.format(Number(n || 0));
 }
 
 const REGION_CURRENCIES = {
@@ -656,7 +658,8 @@ export default function Forecast() {
                   onChange={(e) =>
                     setReach((curr) => ({
                       ...curr,
-                      [r]: parseInt(e.target.value.replace(/,/g, ''), 10) || 0,
+                      [r]:
+                        parseInt(e.target.value.replace(/[^0-9.]/g, ''), 10) || 0,
                     }))
                   }
                 />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,21 +1,867 @@
-
+import { useState, useEffect, useRef } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { usePublishers, computeReach } from '../lib/usePublishers';
+import { useSavedForecasts } from '../lib/useSavedForecasts';
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
 
-export default function Home() {
-  const handleConnect = async () => {
-    window.location.href = 'https://trc-salesgpt-backend.onrender.com/auth/start';
+const REGIONS = ['UK', 'US', 'EU'];
+const SALES_REPS = ['james', 'lucy', 'rebecca', 'ryan', 'preena', 'shamas', 'shaun'];
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+const MONTH_CHANGES = {
+  January: -0.2,
+  February: 0.05,
+  March: 0.05,
+  April: 0.07,
+  May: -0.02,
+  June: 0.03,
+  July: 0.06,
+  August: 0.08,
+  September: 0.04,
+  October: 0.05,
+  November: 0.1,
+  December: 0.1,
+};
+
+// Conversion rates by tier. Reduced by 50% from the previous values so
+// forecasts are more conservative.
+const CONVERSION_BY_TIER = {
+  1: 0.0005,
+  2: 0.00025,
+  3: 0.000125,
+  4: 0.0000625,
+  5: 0.0000425,
+  6: 0.000025,
+};
+
+const MONTH_DELTAS = [0, 0.05, 0.07, -0.02, 0.06, 0.04];
+
+
+function formatNumber(n) {
+  return n.toLocaleString();
+}
+
+const REGION_CURRENCIES = {
+  UK: 'GBP',
+  US: 'USD',
+  EU: 'EUR',
+};
+
+const CURRENCY_SYMBOLS = {
+  GBP: '£',
+  USD: '$',
+  EUR: '€',
+};
+
+function formatCurrency(n, code) {
+  const symbol = CURRENCY_SYMBOLS[code] || '';
+  return (
+    symbol +
+    n.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  );
+}
+
+function computeMonthlyShares(baseShares, weights) {
+  const adjusted = baseShares.map((s, i) => s * (weights[i] || 1));
+  const sum = adjusted.reduce((a, b) => a + b, 0) || 1;
+  return adjusted.map((s) => s / sum);
+}
+
+
+export default function Forecast() {
+  const [retailer, setRetailer] = useState('');
+  const [rep, setRep] = useState(SALES_REPS[0]);
+  const [regions, setRegions] = useState([]);
+  const [tier, setTier] = useState('1');
+  const [online, setOnline] = useState(false);
+  const [instore, setInstore] = useState(false);
+  const [stores, setStores] = useState('');
+  const [aov, setAov] = useState('');
+  const [reach, setReach] = useState({});
+  const [publishers] = usePublishers();
+  const [cashbackExisting, setCashbackExisting] = useState('');
+  const [cashbackNew, setCashbackNew] = useState('');
+  const [results, setResults] = useState(null);
+  const [view, setView] = useState('global');
+  const [startMonth, setStartMonth] = useState(MONTHS[0]);
+  const [theme, setTheme] = useState('light');
+  const [baseShares, setBaseShares] = useState([]);
+  const [weights, setWeights] = useState(Array(6).fill(1));
+  const resultsRef = useRef(null);
+  const [forecasts, addSavedForecast] = useSavedForecasts();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.query.edit || forecasts.length === 0) return;
+    const f = forecasts.find((fc) => fc.id === Number(router.query.edit));
+    if (f && f.inputs) {
+      const inp = f.inputs;
+      setRetailer(inp.retailer || '');
+      setRep(inp.rep || SALES_REPS[0]);
+      setRegions(inp.regions || []);
+      setTier(String(inp.tier || '1'));
+      setOnline(!!inp.online);
+      setInstore(!!inp.instore);
+      setStores(inp.stores || '');
+      setAov(inp.aov || '');
+      setCashbackExisting(inp.cashbackExisting || '');
+      setCashbackNew(inp.cashbackNew || '');
+      setStartMonth(inp.startMonth || MONTHS[0]);
+      setReach(inp.reach || {});
+      if (f.results) setResults(f.results);
+    }
+  }, [router.query.edit, forecasts]);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    const newOnly =
+      parseFloat(cashbackNew) > 0 && (!cashbackExisting || parseFloat(cashbackExisting) === 0);
+    const obj = {};
+    regions.forEach((r) => {
+      const baseReach = computeReach(publishers, r, newOnly);
+      obj[r] = Math.round(baseReach * 0.5);
+    });
+    setReach(obj);
+  }, [regions, cashbackExisting, cashbackNew, publishers]);
+
+  useEffect(() => {
+    if (!results || baseShares.length === 0) return;
+    const aovNum = parseFloat(aov) || 0;
+    const existingCb = parseFloat(cashbackExisting) || 0;
+    const newCb = parseFloat(cashbackNew) || 0;
+    const hasExisting = existingCb > 0;
+    const hasNew = newCb > 0;
+    const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
+    const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
+    const shares = computeMonthlyShares(baseShares, weights);
+    const monthly = shares.map((s) => {
+      const monthOrders = results.total.orders * s;
+      const monthRevenue = monthOrders * aovNum;
+      const monthCashback =
+        monthOrders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
+      return {
+        orders: monthOrders,
+        revenue: monthRevenue,
+        cashback: monthCashback,
+        netRevenue: monthRevenue - monthCashback,
+      };
+    });
+    setResults((prev) => ({ ...prev, monthly }));
+  }, [weights]);
+
+  const GlobalView = () => (
+    <table className="summary-table">
+      <tbody>
+        <tr>
+          <th>Expected Orders</th>
+          <td>{formatNumber(Math.round(results.total.orders))}</td>
+        </tr>
+        <tr>
+          <th>Revenue</th>
+          <td>
+            {formatCurrency(results.total.revenue, results.currency)}
+          </td>
+        </tr>
+        <tr>
+          <th>Total Cashback</th>
+          <td>
+            {formatCurrency(results.total.cashback, results.currency)}
+          </td>
+        </tr>
+        {(() => {
+          const ex = results.cashbackRates?.existing || 0;
+          const nw = results.cashbackRates?.new || 0;
+          if (ex > 0 && nw > 0) {
+            return (
+              <>
+                <tr>
+                  <th>New Customer Total Cashback</th>
+                  <td>{nw}%</td>
+                </tr>
+                <tr>
+                  <th>Existing Customer Total Cashback</th>
+                  <td>{ex}%</td>
+                </tr>
+              </>
+            );
+          }
+          const rate = ex > 0 ? ex : nw;
+          return rate ? (
+            <tr>
+              <th>Total Cashback</th>
+              <td>{rate}%</td>
+            </tr>
+          ) : null;
+        })()}
+        <tr>
+          <th>Net Revenue</th>
+          <td>
+            {formatCurrency(results.total.netRevenue, results.currency)}
+          </td>
+        </tr>
+        <tr>
+          <th>Increase in Basket Spend</th>
+          <td>28%</td>
+        </tr>
+        <tr>
+          <th>ROAS</th>
+          <td>{results.total.roas.toFixed(2)}x</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+
+  const RegionView = () => (
+    <table className="monthly-table">
+      <thead>
+        <tr>
+          <th>Region</th>
+          <th>Orders</th>
+          <th>Revenue</th>
+          <th>Total Cashback</th>
+          <th>Net Revenue</th>
+        </tr>
+      </thead>
+      <tbody>
+        {Object.entries(results.perRegion).map(([r, d]) => (
+          <tr key={r}>
+            <td>
+              {r} ({CURRENCY_SYMBOLS[REGION_CURRENCIES[r]]})
+            </td>
+            <td>{formatNumber(Math.round(d.orders))}</td>
+            <td>{formatCurrency(d.revenue, REGION_CURRENCIES[r])}</td>
+            <td>{formatCurrency(d.cashback, REGION_CURRENCIES[r])}</td>
+            <td>{formatCurrency(d.netRevenue, REGION_CURRENCIES[r])}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  const OfferView = () => (
+    results.offerBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.offerBreakdown).map(([t, d]) => (
+            <tr key={t}>
+              <td>{t}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue, results.currency)}</td>
+              <td>{formatCurrency(d.cashback, results.currency)}</td>
+              <td>{formatCurrency(d.netRevenue, results.currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+  const ChannelView = () => (
+    results.channelBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.channelBreakdown).map(([c, d]) => (
+            <tr key={c}>
+              <td>{c}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue, results.currency)}</td>
+              <td>{formatCurrency(d.cashback, results.currency)}</td>
+              <td>{formatCurrency(d.netRevenue, results.currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+
+  const toggleRegion = (region) => {
+    setRegions((prev) => {
+      if (prev.includes(region)) {
+        const updated = prev.filter((r) => r !== region);
+        setReach((curr) => {
+          const copy = { ...curr };
+          delete copy[region];
+          return copy;
+        });
+        return updated;
+      }
+      setReach((curr) => ({ ...curr, [region]: '' }));
+      return [...prev, region];
+    });
+  };
+
+  const updateWeight = (index, value) => {
+    setWeights((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const calculate = (e) => {
+    e.preventDefault();
+
+    const storeCount = parseInt(stores, 10) || 0;
+    const baseConversion = CONVERSION_BY_TIER[tier] || 0;
+    const storeUplift = instore && storeCount > 0 ? storeCount * 0.000001 : 0;
+    const conversion = baseConversion + storeUplift;
+
+    const aovNum = parseFloat(aov) || 0;
+    const existingCb = parseFloat(cashbackExisting) || 0;
+    const newCb = parseFloat(cashbackNew) || 0;
+
+    const perRegion = {};
+    let totalOrders = 0;
+    let onlineOrdersTotal = 0;
+    let instoreOrdersTotal = 0;
+    regions.forEach((r) => {
+      const regionReach = parseInt(reach[r], 10) || 0;
+      let onlineOrders = 0;
+      let instoreOrders = 0;
+      if (online && instore) {
+        onlineOrders = regionReach * baseConversion;
+        instoreOrders = regionReach * storeUplift;
+      } else if (instore && !online) {
+        instoreOrders = regionReach * conversion;
+      } else {
+        onlineOrders = regionReach * baseConversion;
+      }
+      const orders = onlineOrders + instoreOrders;
+      perRegion[r] = { orders };
+      totalOrders += orders;
+      onlineOrdersTotal += onlineOrders;
+      instoreOrdersTotal += instoreOrders;
+    });
+
+    let existingOrders = 0;
+    let newOrders = 0;
+
+    const hasExisting = existingCb > 0;
+    const hasNew = newCb > 0;
+
+    const computeAmounts = (orders) => {
+      const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
+      const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
+      const revenue = orders * aovNum;
+      const cashback =
+        orders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
+      return {
+        orders,
+        revenue,
+        cashback,
+        netRevenue: revenue - cashback,
+      };
+    };
+
+    if (hasExisting && hasNew) {
+      existingOrders = totalOrders * 0.6;
+      newOrders = totalOrders * 0.4;
+    } else if (hasNew && !hasExisting) {
+      newOrders = totalOrders * 0.4;
+      totalOrders = newOrders;
+    } else {
+      existingOrders = totalOrders;
+    }
+
+    const channelBreakdown =
+      online && instore
+        ? {
+            online: computeAmounts(onlineOrdersTotal),
+            instore: computeAmounts(instoreOrdersTotal),
+          }
+        : null;
+
+    const { revenue, cashback: cashbackAmount, netRevenue } =
+      computeAmounts(totalOrders);
+    const roas = cashbackAmount ? revenue / cashbackAmount : 0;
+
+    Object.keys(perRegion).forEach((r) => {
+      const orders = perRegion[r].orders;
+      let ex = 0;
+      let nw = 0;
+      if (hasExisting && hasNew) {
+        ex = orders * 0.6;
+        nw = orders * 0.4;
+      } else if (hasNew && !hasExisting) {
+        nw = orders * 0.4;
+      } else {
+        ex = orders;
+      }
+      const rev = orders * aovNum;
+      const cashbackAmount =
+        ex * aovNum * (existingCb / 100) + nw * aovNum * (newCb / 100);
+      perRegion[r] = {
+        orders,
+        revenue: rev,
+        cashback: cashbackAmount,
+        netRevenue: rev - cashbackAmount,
+      };
+    });
+
+    const startIndex = MONTHS.indexOf(startMonth);
+    const monthLabels = [];
+    const deltas = [];
+    for (let i = 0; i < 6; i++) {
+      const idx = (startIndex + i) % MONTHS.length;
+      const m = MONTHS[idx];
+      monthLabels.push(m);
+      deltas.push(MONTH_CHANGES[m] || 0);
+    }
+
+    const factors = [];
+    factors[0] = 1 + deltas[0];
+    for (let i = 1; i < 6; i++) {
+      factors[i] = factors[i - 1] * (1 + deltas[i]);
+    }
+    const sumFactors = factors.reduce((a, b) => a + b, 0);
+    const shares = factors.map((f) => f / sumFactors);
+    setBaseShares(shares);
+    setWeights(Array(6).fill(1));
+    const adjShares = computeMonthlyShares(shares, Array(6).fill(1));
+    const monthly = adjShares.map((s) => {
+      const monthOrders = totalOrders * s;
+      const exRatio = hasExisting && hasNew ? 0.6 : hasNew && !hasExisting ? 0 : 1;
+      const nwRatio = hasExisting && hasNew ? 0.4 : hasNew && !hasExisting ? 1 : 0;
+      const monthRevenue = monthOrders * aovNum;
+      const monthCashback =
+        monthOrders * aovNum * ((existingCb * exRatio + newCb * nwRatio) / 100);
+      return {
+        orders: monthOrders,
+        revenue: monthRevenue,
+        cashback: monthCashback,
+        netRevenue: monthRevenue - monthCashback,
+      };
+    });
+
+    const offerBreakdown =
+      hasExisting && hasNew
+        ? {
+            existing: {
+              orders: existingOrders,
+              revenue: existingOrders * aovNum,
+              cashback: existingOrders * aovNum * (existingCb / 100),
+              netRevenue:
+                existingOrders * aovNum -
+                existingOrders * aovNum * (existingCb / 100),
+            },
+            new: {
+              orders: newOrders,
+              revenue: newOrders * aovNum,
+              cashback: newOrders * aovNum * (newCb / 100),
+              netRevenue: newOrders * aovNum - newOrders * aovNum * (newCb / 100),
+            },
+          }
+        : null;
+
+    let bestRegion = regions[0];
+    let maxOrders = perRegion[bestRegion]?.orders || 0;
+    regions.forEach((r) => {
+      if ((perRegion[r]?.orders || 0) > maxOrders) {
+        bestRegion = r;
+        maxOrders = perRegion[r].orders;
+      }
+    });
+    const currency = REGION_CURRENCIES[bestRegion] || 'GBP';
+
+    setResults({
+      total: {
+        orders: totalOrders,
+        revenue,
+        cashback: cashbackAmount,
+        netRevenue,
+        roas,
+      },
+      perRegion,
+      monthly,
+      monthLabels,
+      offerBreakdown,
+      channelBreakdown,
+      currency,
+      cashbackRates: {
+        existing: existingCb,
+        new: newCb,
+      },
+    });
+  };
+
+  const downloadPdf = async () => {
+    if (!resultsRef.current) return;
+    const sliderRow = resultsRef.current.querySelector('.slider-row');
+    const viewToggle = resultsRef.current.querySelector('.view-toggle');
+    const prevSlider = sliderRow ? sliderRow.style.display : '';
+    const prevView = viewToggle ? viewToggle.style.display : '';
+    if (sliderRow) sliderRow.style.display = 'none';
+    if (viewToggle) viewToggle.style.display = 'none';
+    const canvas = await html2canvas(resultsRef.current);
+    if (sliderRow) sliderRow.style.display = prevSlider;
+    if (viewToggle) viewToggle.style.display = prevView;
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF('p', 'mm', 'a4');
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const imgWidth = pageWidth;
+    const imgHeight = (canvas.height * imgWidth) / canvas.width;
+    let position = 0;
+    pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+    let heightLeft = imgHeight - pdf.internal.pageSize.getHeight();
+    while (heightLeft > 0) {
+      position -= pdf.internal.pageSize.getHeight();
+      pdf.addPage();
+      pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+      heightLeft -= pdf.internal.pageSize.getHeight();
+    }
+    const fileName = retailer ? `${retailer}-6-month-forecast.pdf` : '6-month-forecast.pdf';
+    pdf.save(fileName);
+  };
+
+  const saveForecast = () => {
+    if (!results) return;
+    addSavedForecast({
+      type: 'forecast',
+      retailer,
+      rep,
+      inputs: {
+        retailer,
+        rep,
+        regions,
+        tier,
+        online,
+        instore,
+        stores,
+        aov,
+        cashbackExisting,
+        cashbackNew,
+        startMonth,
+        reach,
+      },
+      results,
+    });
+    alert('Forecast saved');
   };
 
   return (
-    <div style={{ padding: '40px' }}>
+    <>
       <Head>
-        <title>TRC SalesGPT</title>
-        <meta name="description" content="Connect Microsoft Account" />
-        <link rel="icon" href="/favicon.ico" />
+        <title>The Reward Collection Forecasting Tool</title>
       </Head>
+      <main className="container">
+        <div className="top-bar">
+          <div className="nav-links">
+            <Link href="/">Forecasting</Link>
+            <Link href="/publishers">Publishers</Link>
+            <Link href="/publisher-forecast">Publisher Forecasts</Link>
+            <Link href="/saved-forecasts">Saved Forecasts</Link>
+          </div>
+          <div className="theme-switch">
+            <button
+              type="button"
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            >
+              {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+            </button>
+          </div>
+        </div>
+        <h1>The Reward Collection Forecasting Tool</h1>
+        <p style={{ textAlign: 'center' }}>
+          Enter campaign details below to estimate performance.
+        </p>
+          <form onSubmit={calculate} className="form">
+            <label className="full-width">
+              Sales Rep
+              <select value={rep} onChange={(e) => setRep(e.target.value)}>
+                {SALES_REPS.map((r) => (
+                  <option key={r} value={r}>
+                    {r.charAt(0).toUpperCase() + r.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="full-width">
+              Retailer Name
+              <input
+                type="text"
+                value={retailer}
+                onChange={(e) => setRetailer(e.target.value)}
+                required
+              />
+            </label>
+            <label className="full-width">
+              Starting Month
+              <select value={startMonth} onChange={(e) => setStartMonth(e.target.value)}>
+                {MONTHS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <fieldset className="region-group full-width">
+              <legend>Regions</legend>
+              {REGIONS.map((r) => (
+                <label key={r} className="checkbox">
+                  <input
+                    type="checkbox"
+                  checked={regions.includes(r)}
+                  onChange={() => toggleRegion(r)}
+                />
+                {r}
+              </label>
+            ))}
+          </fieldset>
+            {regions.map((r) => (
+              <label key={`reach-${r}`} className="reach-input">
+                Reach {r}
+                <input
+                  type="text"
+                  value={reach[r] ? formatNumber(reach[r]) : ''}
+                  onChange={(e) =>
+                    setReach((curr) => ({
+                      ...curr,
+                      [r]: parseInt(e.target.value.replace(/,/g, ''), 10) || 0,
+                    }))
+                  }
+                />
+              </label>
+            ))}
+          <label>
+            Tier
+            <select value={tier} onChange={(e) => setTier(e.target.value)}>
+              {[1, 2, 3, 4, 5, 6].map((t) => (
+                <option key={t} value={t}>
+                  Tier {t}
+                </option>
+              ))}
+            </select>
+          </label>
+            <div className="checkbox-row">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={online}
+                  onChange={(e) => setOnline(e.target.checked)}
+                />
+                Online
+              </label>
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={instore}
+                  onChange={(e) => setInstore(e.target.checked)}
+                />
+                In-store
+              </label>
+            </div>
+          {instore && (
+            <label>
+              Number of Stores
+              <input
+                type="number"
+                value={stores}
+                onChange={(e) => setStores(e.target.value)}
+                min="0"
+              />
+            </label>
+          )}
+          <label>
+            Average Order Value
+            <input
+              type="number"
+              value={aov}
+              onChange={(e) => setAov(e.target.value)}
+            />
+          </label>
+          <label>
+            Cashback Existing %
+            <input
+              type="number"
+              value={cashbackExisting}
+              onChange={(e) => setCashbackExisting(e.target.value)}
+            />
+          </label>
+          <label>
+            Cashback New %
+            <input
+              type="number"
+              value={cashbackNew}
+              onChange={(e) => setCashbackNew(e.target.value)}
+            />
+          </label>
+          <button type="submit" className="full-width">Calculate Forecast</button>
+        </form>
+        {results && (
+          <div className="results">
+            <div className="view-toggle">
+              <select value={view} onChange={(e) => setView(e.target.value)}>
+                <option value="global">High Level Campaign Metrics</option>
+                <option value="region">By Region</option>
+                {results.offerBreakdown && (
+                  <option value="offer">By Offer Type</option>
+                )}
+                {results.channelBreakdown && (
+                  <option value="channel">By Channel</option>
+                )}
+                <option value="all">View All</option>
+              </select>
+              <button type="button" onClick={downloadPdf}>Download PDF</button>
+            </div>
+            <div ref={resultsRef}>
+            <h2>{retailer ? `${retailer} 6-Month Forecast` : '6-Month Forecast'}</h2>
+            {view === 'global' && <GlobalView />}
+            {view === 'region' && <RegionView />}
+            {view === 'offer' && <OfferView />}
+            {view === 'channel' && <ChannelView />}
+            {view === 'all' && (
+              <div className="side-by-side">
+                <div>
+                  <h3>High Level Campaign Metrics</h3>
+                  <GlobalView />
+                </div>
+                <div>
+                  <h3>By Region</h3>
+                  <RegionView />
+                </div>
+                {results.offerBreakdown && (
+                  <div>
+                    <h3>By Offer Type</h3>
+                    <OfferView />
+                  </div>
+                )}
+                {results.channelBreakdown && (
+                  <div>
+                    <h3>By Channel</h3>
+                    <ChannelView />
+                  </div>
+                )}
+              </div>
+            )}
 
-      <h1 style={{ fontSize: '2.5rem' }}>Welcome to TRC SalesGPT</h1>
-      <button onClick={handleConnect}>Connect Microsoft</button>
-    </div>
+            <h3>Monthly Projection</h3>
+            <table className="monthly-table">
+              <thead>
+                <tr>
+                  <th></th>
+                  {results.monthLabels.map((m, i) => (
+                    <th key={i}>{m}</th>
+                  ))}
+                  <th>Total</th>
+                </tr>
+                <tr className="slider-row">
+                  <th>Adjust</th>
+                  {weights.map((w, i) => (
+                    <th key={i}>
+                      <input
+                        type="range"
+                        min="0.5"
+                        max="1.5"
+                        step="0.01"
+                        value={w}
+                        onChange={(e) => updateWeight(i, parseFloat(e.target.value))}
+                      />
+                    </th>
+                  ))}
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {(() => {
+                  const makeRow = (label, arr, formatter) => {
+                    const total = arr.reduce((a, b) => a + b, 0);
+                    return (
+                      <tr>
+                        <td>{label}</td>
+                        {arr.map((v, i) => (
+                          <td key={i}>{formatter(v)}</td>
+                        ))}
+                        <td>{formatter(total)}</td>
+                      </tr>
+                    );
+                  };
+                  return (
+                    <>
+                      {makeRow(
+                        'Orders',
+                        results.monthly.map((m) => m.orders),
+                        (v) => formatNumber(Math.round(v))
+                      )}
+                      {makeRow(
+                        'Revenue',
+                        results.monthly.map((m) => m.revenue),
+                        (v) => formatCurrency(v, results.currency)
+                      )}
+                      {makeRow(
+                        'Total Cashback',
+                        results.monthly.map((m) => m.cashback),
+                        (v) => formatCurrency(v, results.currency)
+                      )}
+                      {makeRow(
+                        'Net Revenue',
+                        results.monthly.map((m) => m.netRevenue),
+                        (v) => formatCurrency(v, results.currency)
+                      )}
+                    </>
+                  );
+                })()}
+              </tbody>
+            </table>
+            <p className="disclaimer">
+              <strong>Disclaimer:</strong>
+              <br />
+              The projections outlined in this forecast are based on historical sales data and are influenced by a range of dynamic variables. While they offer a directional view of potential performance, they should not be considered fixed budgets or guaranteed outcomes. The Reward Collection provides these insights to help guide strategic planning and campaign alignment.
+              <br />
+              <br />
+              We look forward to continuing our discussions and exploring the opportunities ahead.
+              <br />
+              <br />
+              Warm regards,
+              <br />
+              {rep.charAt(0).toUpperCase() + rep.slice(1)}
+              <br />
+              {rep}@thewardcollection.com
+            </p>
+            <button type="button" onClick={saveForecast}>Save Forecast</button>
+            </div>
+          </div>
+        )}
+      </main>
+    </>
   );
 }

--- a/pages/publisher-forecast.js
+++ b/pages/publisher-forecast.js
@@ -295,9 +295,9 @@ export default function PublisherForecast() {
     pdf.save(`${retailer || 'forecast'}-publisher-forecast.pdf`);
   };
 
-  const saveForecast = () => {
+  const saveForecast = async () => {
     if (!results) return;
-    addSavedForecast({
+    await addSavedForecast({
       type: 'publisher',
       retailer,
       publisher,

--- a/pages/publisher-forecast.js
+++ b/pages/publisher-forecast.js
@@ -28,13 +28,13 @@ const MONTH_CHANGES = {
 const CURRENCY_SYMBOLS = { GBP: '£', USD: '$', EUR: '€' };
 
 function formatNumber(n) {
-  return n.toLocaleString();
+  return Number(n || 0).toLocaleString('en-US');
 }
 
 function formatCurrency(n, code) {
   const symbol = CURRENCY_SYMBOLS[code] || '';
   return (
-    symbol + n.toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2})
+    symbol + Number(n || 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
   );
 }
 

--- a/pages/publisher-forecast.js
+++ b/pages/publisher-forecast.js
@@ -31,6 +31,17 @@ function formatNumber(n) {
   return Number(n || 0).toLocaleString('en-US');
 }
 
+function formatInputValue(v) {
+  if (v === '' || v === null || v === undefined) return '';
+  const parts = String(v).split('.');
+  parts[0] = Number(parts[0]).toLocaleString('en-US');
+  return parts.join('.');
+}
+
+function parseInputValue(v) {
+  return v.replace(/,/g, '');
+}
+
 function formatCurrency(n, code) {
   const symbol = CURRENCY_SYMBOLS[code] || '';
   return (
@@ -460,34 +471,34 @@ export default function PublisherForecast() {
           {mode==='always' ? (
             <>
               <label className="full-width">Transaction Count
-                <input type="number" value={allTx} onChange={e=>setAllTx(e.target.value)} />
+                <input type="text" value={formatInputValue(allTx)} onChange={e=>setAllTx(parseInputValue(e.target.value))} />
               </label>
               <label className="full-width">Transaction Revenue
-                <input type="number" value={allRevenue} onChange={e=>setAllRevenue(e.target.value)} />
+                <input type="text" value={formatInputValue(allRevenue)} onChange={e=>setAllRevenue(parseInputValue(e.target.value))} />
               </label>
               <label className="full-width">Cashback %
-                <input type="number" value={allCashback} onChange={e=>setAllCashback(e.target.value)} />
+                <input type="text" value={formatInputValue(allCashback)} onChange={e=>setAllCashback(parseInputValue(e.target.value))} />
               </label>
             </>
           ) : (
             <>
               <label className="full-width">Existing Transaction Count
-                <input type="number" value={existingTx} onChange={e=>setExistingTx(e.target.value)} />
+                <input type="text" value={formatInputValue(existingTx)} onChange={e=>setExistingTx(parseInputValue(e.target.value))} />
               </label>
               <label className="full-width">Existing Customer Revenue
-                <input type="number" value={existingRevenue} onChange={e=>setExistingRevenue(e.target.value)} />
+                <input type="text" value={formatInputValue(existingRevenue)} onChange={e=>setExistingRevenue(parseInputValue(e.target.value))} />
               </label>
               <label className="full-width">Existing Cashback %
-                <input type="number" value={existingCashback} onChange={e=>setExistingCashback(e.target.value)} />
+                <input type="text" value={formatInputValue(existingCashback)} onChange={e=>setExistingCashback(parseInputValue(e.target.value))} />
               </label>
               <label className="full-width">New Transaction Count
-                <input type="number" value={newTx} onChange={e=>setNewTx(e.target.value)} />
+                <input type="text" value={formatInputValue(newTx)} onChange={e=>setNewTx(parseInputValue(e.target.value))} />
               </label>
               <label className="full-width">New Customer Revenue
-                <input type="number" value={newRevenue} onChange={e=>setNewRevenue(e.target.value)} />
+                <input type="text" value={formatInputValue(newRevenue)} onChange={e=>setNewRevenue(parseInputValue(e.target.value))} />
               </label>
           <label className="full-width">New Cashback %
-            <input type="number" value={newCashback} onChange={e=>setNewCashback(e.target.value)} />
+            <input type="text" value={formatInputValue(newCashback)} onChange={e=>setNewCashback(parseInputValue(e.target.value))} />
           </label>
         </>
       )}
@@ -499,10 +510,10 @@ export default function PublisherForecast() {
         {instore && (
           <>
             <label className="full-width">In-store Transaction Count
-              <input type="number" value={instoreTx} onChange={e=>setInstoreTx(e.target.value)} />
+              <input type="text" value={formatInputValue(instoreTx)} onChange={e=>setInstoreTx(parseInputValue(e.target.value))} />
             </label>
             <label className="full-width">In-store Revenue
-              <input type="number" value={instoreRevenue} onChange={e=>setInstoreRevenue(e.target.value)} />
+              <input type="text" value={formatInputValue(instoreRevenue)} onChange={e=>setInstoreRevenue(parseInputValue(e.target.value))} />
             </label>
           </>
         )}
@@ -593,15 +604,15 @@ export default function PublisherForecast() {
               <div className="trc-section">
                 {mode==='always' ? (
                   <label className="full-width">TRC Margin %
-                    <input type="number" value={trcMargin} onChange={e=>setTrcMargin(e.target.value)} />
+                    <input type="text" value={formatInputValue(trcMargin)} onChange={e=>setTrcMargin(parseInputValue(e.target.value))} />
                   </label>
                 ) : (
                   <>
                     <label className="full-width">TRC Margin Existing %
-                      <input type="number" value={trcMarginExisting} onChange={e=>setTrcMarginExisting(e.target.value)} />
+                      <input type="text" value={formatInputValue(trcMarginExisting)} onChange={e=>setTrcMarginExisting(parseInputValue(e.target.value))} />
                     </label>
                     <label className="full-width">TRC Margin New %
-                      <input type="number" value={trcMarginNew} onChange={e=>setTrcMarginNew(e.target.value)} />
+                      <input type="text" value={formatInputValue(trcMarginNew)} onChange={e=>setTrcMarginNew(parseInputValue(e.target.value))} />
                     </label>
                   </>
                 )}

--- a/pages/publisher-forecast.js
+++ b/pages/publisher-forecast.js
@@ -27,19 +27,21 @@ const MONTH_CHANGES = {
 
 const CURRENCY_SYMBOLS = { GBP: '£', USD: '$', EUR: '€' };
 
+const NUM_FORMAT = new Intl.NumberFormat('en-US');
+
 function formatNumber(n) {
-  return Number(n || 0).toLocaleString('en-US');
+  return NUM_FORMAT.format(Number(n || 0));
 }
 
 function formatInputValue(v) {
   if (v === '' || v === null || v === undefined) return '';
   const parts = String(v).split('.');
-  parts[0] = Number(parts[0]).toLocaleString('en-US');
+  parts[0] = NUM_FORMAT.format(Number(parts[0].replace(/,/g, '')));
   return parts.join('.');
 }
 
 function parseInputValue(v) {
-  return v.replace(/,/g, '');
+  return v.replace(/[^0-9.]/g, '');
 }
 
 function formatCurrency(n, code) {

--- a/pages/publisher-forecast.js
+++ b/pages/publisher-forecast.js
@@ -1,0 +1,647 @@
+import { useState, useEffect, useRef } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
+import { useSavedForecasts } from '../lib/useSavedForecasts';
+
+const MANAGERS = ['tayla', 'laura'];
+const MONTHS = [
+  'January','February','March','April','May','June','July','August','September','October','November','December'
+];
+const MONTH_CHANGES = {
+  January: -0.2,
+  February: 0.05,
+  March: 0.05,
+  April: 0.07,
+  May: -0.02,
+  June: 0.03,
+  July: 0.06,
+  August: 0.08,
+  September: 0.04,
+  October: 0.05,
+  November: 0.1,
+  December: 0.1,
+};
+
+const CURRENCY_SYMBOLS = { GBP: '£', USD: '$', EUR: '€' };
+
+function formatNumber(n) {
+  return n.toLocaleString();
+}
+
+function formatCurrency(n, code) {
+  const symbol = CURRENCY_SYMBOLS[code] || '';
+  return (
+    symbol + n.toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2})
+  );
+}
+
+function computeMonthlyShares(baseShares, weights) {
+  const adjusted = baseShares.map((s,i)=>s*(weights[i]||1));
+  const sum = adjusted.reduce((a,b)=>a+b,0) || 1;
+  return adjusted.map(s=>s/sum);
+}
+
+export default function PublisherForecast() {
+  const [manager,setManager] = useState(MANAGERS[0]);
+  const [publisher,setPublisher] = useState('');
+  const [retailer,setRetailer] = useState('');
+  const [currency,setCurrency] = useState('GBP');
+  const [forecastLength,setForecastLength] = useState('6');
+  const [startMonth,setStartMonth] = useState(MONTHS[0]);
+  const [mode,setMode] = useState('always');
+  const [instore,setInstore] = useState(false);
+  const [instoreTx,setInstoreTx] = useState('');
+  const [instoreRevenue,setInstoreRevenue] = useState('');
+  const [allTx,setAllTx] = useState('');
+  const [allRevenue,setAllRevenue] = useState('');
+  const [allCashback,setAllCashback] = useState('');
+  const [existingTx,setExistingTx] = useState('');
+  const [existingRevenue,setExistingRevenue] = useState('');
+  const [existingCashback,setExistingCashback] = useState('');
+  const [newTx,setNewTx] = useState('');
+  const [newRevenue,setNewRevenue] = useState('');
+  const [newCashback,setNewCashback] = useState('');
+  const [otherDetails,setOtherDetails] = useState('');
+  const [trcMargin,setTrcMargin] = useState('');
+  const [trcMarginExisting,setTrcMarginExisting] = useState('');
+  const [trcMarginNew,setTrcMarginNew] = useState('');
+  const [results,setResults] = useState(null);
+  const [view,setView] = useState('global');
+  const [theme,setTheme] = useState('light');
+  const [showTrc,setShowTrc] = useState(false);
+  const [baseShares,setBaseShares] = useState([]);
+  const [weights,setWeights] = useState([]);
+  const resultsRef = useRef(null);
+  const [forecasts, addSavedForecast] = useSavedForecasts();
+  const router = useRouter();
+
+  useEffect(()=>{document.documentElement.dataset.theme = theme;},[theme]);
+
+  useEffect(() => {
+    if (!router.query.edit || forecasts.length === 0) return;
+    const f = forecasts.find((fc) => fc.id === Number(router.query.edit));
+    if (f && f.inputs) {
+      const inp = f.inputs;
+      setManager(inp.manager || MANAGERS[0]);
+      setPublisher(inp.publisher || '');
+      setRetailer(inp.retailer || '');
+      setCurrency(inp.currency || 'GBP');
+      setForecastLength(inp.forecastLength || '6');
+      setStartMonth(inp.startMonth || MONTHS[0]);
+      setMode(inp.mode || 'always');
+      setInstore(!!inp.instore);
+      setInstoreTx(inp.instoreTx || '');
+      setInstoreRevenue(inp.instoreRevenue || '');
+      setAllTx(inp.allTx || '');
+      setAllRevenue(inp.allRevenue || '');
+      setAllCashback(inp.allCashback || '');
+      setExistingTx(inp.existingTx || '');
+      setExistingRevenue(inp.existingRevenue || '');
+      setExistingCashback(inp.existingCashback || '');
+      setNewTx(inp.newTx || '');
+      setNewRevenue(inp.newRevenue || '');
+      setNewCashback(inp.newCashback || '');
+      setOtherDetails(inp.otherDetails || '');
+      setTrcMargin(inp.trcMargin || '');
+      setTrcMarginExisting(inp.trcMarginExisting || '');
+      setTrcMarginNew(inp.trcMarginNew || '');
+      if (f.results) setResults(f.results);
+    }
+  }, [router.query.edit, forecasts]);
+
+  useEffect(()=>{
+    if(!results || baseShares.length===0) return;
+    const orders = results.total.orders;
+    const revenue = results.total.revenue;
+    const cashback = results.total.cashback;
+    const shares = computeMonthlyShares(baseShares,weights);
+    const monthly = shares.map(s=>({
+      orders: orders*s,
+      revenue: revenue*s,
+      cashback: cashback*s,
+      netRevenue: revenue*s - cashback*s,
+    }));
+    const trc = shares.map((s,i)=>{
+      if(mode==='always'){
+        const m=parseFloat(trcMargin)||0;
+        return revenue*s*(m/100);
+      }else{
+        const exRev=parseFloat(existingRevenue)||0;
+        const nwRev=parseFloat(newRevenue)||0;
+        const mE=parseFloat(trcMarginExisting)||0;
+        const mN=parseFloat(trcMarginNew)||0;
+        return exRev*s*(mE/100)+nwRev*s*(mN/100);
+      }
+    });
+    setResults(prev=>({...prev,monthly,trcMonthly:trc,trcRevenue:trc.reduce((a,b)=>a+b,0)}));
+  },[weights,trcMargin,trcMarginExisting,trcMarginNew]);
+
+  const updateWeight = (idx,val)=>{
+    setWeights(prev=>{const next=[...prev]; next[idx]=val; return next;});
+  };
+
+  const calculate=(e)=>{
+    e.preventDefault();
+
+    let orders=0;
+    let revenue=0;
+    let cashback=0;
+    let onlineOrders=0, onlineRevenue=0, onlineCashback=0;
+    let instOrders=0, instRevenue=0, instCashback=0;
+    let offerBreakdown=null;
+    let cashbackSplit=null;
+
+    if(mode==='always'){
+      onlineOrders = parseInt(allTx,10)||0;
+      onlineRevenue = parseFloat(allRevenue)||0;
+      const cbPct = parseFloat(allCashback)||0;
+      onlineCashback = onlineRevenue * (cbPct/100);
+      if(instore){
+        instOrders = parseInt(instoreTx,10)||0;
+        instRevenue = parseFloat(instoreRevenue)||0;
+        instCashback = instRevenue * (cbPct/100);
+      }
+      orders = onlineOrders + instOrders;
+      revenue = onlineRevenue + instRevenue;
+      cashback = onlineCashback + instCashback;
+    }else{
+      const exOrders = parseInt(existingTx,10)||0;
+      const nwOrders = parseInt(newTx,10)||0;
+      const exRev = parseFloat(existingRevenue)||0;
+      const nwRev = parseFloat(newRevenue)||0;
+      const exPct = parseFloat(existingCashback)||0;
+      const nwPct = parseFloat(newCashback)||0;
+      const exCb = exRev * (exPct/100);
+      const nwCb = nwRev * (nwPct/100);
+      onlineOrders = exOrders + nwOrders;
+      onlineRevenue = exRev + nwRev;
+      onlineCashback = exCb + nwCb;
+      if(instore){
+        const avgPct = (exPct + nwPct) / 2;
+        instOrders = parseInt(instoreTx,10)||0;
+        instRevenue = parseFloat(instoreRevenue)||0;
+        instCashback = instRevenue * (avgPct/100);
+      }
+      orders = onlineOrders + instOrders;
+      revenue = onlineRevenue + instRevenue;
+      cashback = onlineCashback + instCashback;
+      offerBreakdown={
+        existing:{orders:exOrders,revenue:exRev,cashback:exCb,netRevenue:exRev-exCb},
+        new:{orders:nwOrders,revenue:nwRev,cashback:nwCb,netRevenue:nwRev-nwCb}
+      };
+      cashbackSplit={existing:exCb,new:nwCb};
+    }
+    const netRevenue = revenue - cashback;
+    const roas = cashback? revenue/cashback : 0;
+    const aov = orders? revenue/orders : 0;
+
+    const length=parseInt(forecastLength,10)||6;
+    const startIdx=MONTHS.indexOf(startMonth);
+    const monthLabels=[]; const deltas=[];
+    for(let i=0;i<length;i++){
+      const idx=(startIdx+i)%MONTHS.length;
+      const m=MONTHS[idx];
+      monthLabels.push(m);
+      deltas.push(MONTH_CHANGES[m]||0);
+    }
+    const factors=[]; factors[0]=1+deltas[0];
+    for(let i=1;i<length;i++){factors[i]=factors[i-1]*(1+deltas[i]);}
+    const sumFactors=factors.reduce((a,b)=>a+b,0);
+    const shares=factors.map(f=>f/sumFactors);
+    setBaseShares(shares); setWeights(Array(length).fill(1));
+    const monthly=shares.map(s=>({orders:orders*s,revenue:revenue*s,cashback:cashback*s,netRevenue:revenue*s-cashback*s}));
+    let channelBreakdown=null;
+    if(instore){
+      channelBreakdown={
+        online:{orders:onlineOrders,revenue:onlineRevenue,cashback:onlineCashback,netRevenue:onlineRevenue-onlineCashback},
+        instore:{orders:instOrders,revenue:instRevenue,cashback:instCashback,netRevenue:instRevenue-instCashback}
+      };
+    }
+    const cashbackRates =
+      mode === 'always'
+        ? { existing: parseFloat(allCashback) || 0 }
+        : {
+            existing: parseFloat(existingCashback) || 0,
+            new: parseFloat(newCashback) || 0,
+          };
+
+    setResults({
+      total: { orders, revenue, cashback, netRevenue, roas, aov },
+      monthLabels,
+      monthly,
+      offerBreakdown,
+      channelBreakdown,
+      cashbackSplit,
+      cashbackRates,
+      manager,
+      currency,
+      publisher,
+    });
+  };
+
+  const downloadPdf = async () => {
+    if (!resultsRef.current) return;
+    const viewToggle = resultsRef.current.querySelector('.view-toggle');
+    const sliderRow = resultsRef.current.querySelector('.slider-row');
+    const saveBtn = resultsRef.current.querySelector('.save-btn');
+    const trcSection = resultsRef.current.querySelector('.trc-section');
+    const trcBtn = resultsRef.current.querySelector('.trc-toggle-btn');
+    const prevView = viewToggle ? viewToggle.style.display : '';
+    const prevSlider = sliderRow ? sliderRow.style.display : '';
+    const prevSave = saveBtn ? saveBtn.style.display : '';
+    const prevTrc = trcSection ? trcSection.style.display : '';
+    const prevTrcBtn = trcBtn ? trcBtn.style.display : '';
+    if (viewToggle) viewToggle.style.display = 'none';
+    if (sliderRow) sliderRow.style.display = 'none';
+    if (saveBtn) saveBtn.style.display = 'none';
+    if (trcSection) trcSection.style.display = 'none';
+    if (trcBtn) trcBtn.style.display = 'none';
+    const canvas = await html2canvas(resultsRef.current);
+    if (viewToggle) viewToggle.style.display = prevView;
+    if (sliderRow) sliderRow.style.display = prevSlider;
+    if (saveBtn) saveBtn.style.display = prevSave;
+    if (trcSection) trcSection.style.display = prevTrc;
+    if (trcBtn) trcBtn.style.display = prevTrcBtn;
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF('p', 'mm', 'a4');
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const imgWidth = pageWidth;
+    const imgHeight = (canvas.height * imgWidth) / canvas.width;
+    let position = 0;
+    pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+    let heightLeft = imgHeight - pdf.internal.pageSize.getHeight();
+    while (heightLeft > 0) {
+      position -= pdf.internal.pageSize.getHeight();
+      pdf.addPage();
+      pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+      heightLeft -= pdf.internal.pageSize.getHeight();
+    }
+    pdf.save(`${retailer || 'forecast'}-publisher-forecast.pdf`);
+  };
+
+  const saveForecast = () => {
+    if (!results) return;
+    addSavedForecast({
+      type: 'publisher',
+      retailer,
+      publisher,
+      manager,
+      inputs: {
+        manager,
+        publisher,
+        retailer,
+        currency,
+        forecastLength,
+        startMonth,
+        mode,
+        instore,
+        instoreTx,
+        instoreRevenue,
+        allTx,
+        allRevenue,
+        allCashback,
+        existingTx,
+        existingRevenue,
+        existingCashback,
+        newTx,
+        newRevenue,
+        newCashback,
+        otherDetails,
+        trcMargin,
+        trcMarginExisting,
+        trcMarginNew,
+      },
+      results,
+    });
+    alert('Forecast saved');
+  };
+
+  const GlobalView = () => (
+    <table className="summary-table">
+      <tbody>
+        <tr><th>Publisher</th><td>{publisher}</td></tr>
+        {(() => {
+          const ex = results.cashbackRates?.existing || 0;
+          const nw = results.cashbackRates?.new || 0;
+          if (ex > 0 && nw > 0) {
+            return (
+              <>
+                <tr><th>New Customer Total Cashback</th><td>{nw}%</td></tr>
+                <tr><th>Existing Customer Total Cashback</th><td>{ex}%</td></tr>
+              </>
+            );
+          }
+          const rate = ex > 0 ? ex : nw;
+          return rate ? (
+            <tr><th>Total Cashback</th><td>{rate}%</td></tr>
+          ) : null;
+        })()}
+        {otherDetails && <tr><th>Other Offer Details</th><td>{otherDetails}</td></tr>}
+        <tr><th>Transaction Count</th><td>{formatNumber(Math.round(results.total.orders))}</td></tr>
+        <tr><th>Revenue</th><td>{formatCurrency(results.total.revenue,currency)}</td></tr>
+        <tr><th>Total Cashback</th><td>{formatCurrency(results.total.cashback,currency)}</td></tr>
+        <tr><th>Net Revenue</th><td>{formatCurrency(results.total.netRevenue,currency)}</td></tr>
+        <tr><th>Average Order Value</th><td>{formatCurrency(results.total.aov,currency)}</td></tr>
+        <tr><th>ROAS</th><td>{results.total.roas.toFixed(2)}x</td></tr>
+      </tbody>
+    </table>
+  );
+
+  const OfferView = () => (
+    results.offerBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.offerBreakdown).map(([t,d])=> (
+            <tr key={t}>
+              <td>{t}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue,currency)}</td>
+              <td>{formatCurrency(d.cashback,currency)}</td>
+              <td>{formatCurrency(d.netRevenue,currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+  const ChannelView = () => (
+    results.channelBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.channelBreakdown).map(([c,d]) => (
+            <tr key={c}>
+              <td>{c}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue,currency)}</td>
+              <td>{formatCurrency(d.cashback,currency)}</td>
+              <td>{formatCurrency(d.netRevenue,currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+  return (
+    <>
+      <Head><title>Publisher Forecasts</title></Head>
+      <main className="container">
+        <div className="top-bar">
+          <div className="nav-links">
+            <Link href="/">Forecasting</Link>
+            <Link href="/publishers">Publishers</Link>
+            <Link href="/publisher-forecast">Publisher Forecasts</Link>
+            <Link href="/saved-forecasts">Saved Forecasts</Link>
+          </div>
+          <div className="theme-switch">
+            <button type="button" onClick={()=>setTheme(theme==='dark'?'light':'dark')}>
+              {theme==='dark'?'Light Mode':'Dark Mode'}
+            </button>
+          </div>
+        </div>
+        <h1>Publisher Forecasts</h1>
+        <form onSubmit={calculate} className="form">
+          <label className="full-width">Account Manager
+            <select value={manager} onChange={e=>setManager(e.target.value)}>
+              {MANAGERS.map(m=>(
+                <option key={m} value={m}>{m.charAt(0).toUpperCase()+m.slice(1)}</option>
+              ))}
+            </select>
+          </label>
+          <label className="full-width">Publisher Name
+            <input value={publisher} onChange={e=>setPublisher(e.target.value)} required />
+          </label>
+          <label className="full-width">Retailer Name
+            <input value={retailer} onChange={e=>setRetailer(e.target.value)} required />
+          </label>
+          <label>Currency
+            <select value={currency} onChange={e=>setCurrency(e.target.value)}>
+              <option value="GBP">GBP</option>
+              <option value="USD">USD</option>
+              <option value="EUR">EUR</option>
+            </select>
+          </label>
+          <label>Forecast Length
+            <select value={forecastLength} onChange={e=>setForecastLength(e.target.value)}>
+              <option value="3">3 Months</option>
+              <option value="6">6 Months</option>
+              <option value="9">9 Months</option>
+              <option value="12">12 Months</option>
+            </select>
+          </label>
+          <label>Starting Month
+            <select value={startMonth} onChange={e=>setStartMonth(e.target.value)}>
+              {MONTHS.map(m=>(<option key={m} value={m}>{m}</option>))}
+            </select>
+          </label>
+
+          {mode==='always' ? (
+            <>
+              <label className="full-width">Transaction Count
+                <input type="number" value={allTx} onChange={e=>setAllTx(e.target.value)} />
+              </label>
+              <label className="full-width">Transaction Revenue
+                <input type="number" value={allRevenue} onChange={e=>setAllRevenue(e.target.value)} />
+              </label>
+              <label className="full-width">Cashback %
+                <input type="number" value={allCashback} onChange={e=>setAllCashback(e.target.value)} />
+              </label>
+            </>
+          ) : (
+            <>
+              <label className="full-width">Existing Transaction Count
+                <input type="number" value={existingTx} onChange={e=>setExistingTx(e.target.value)} />
+              </label>
+              <label className="full-width">Existing Customer Revenue
+                <input type="number" value={existingRevenue} onChange={e=>setExistingRevenue(e.target.value)} />
+              </label>
+              <label className="full-width">Existing Cashback %
+                <input type="number" value={existingCashback} onChange={e=>setExistingCashback(e.target.value)} />
+              </label>
+              <label className="full-width">New Transaction Count
+                <input type="number" value={newTx} onChange={e=>setNewTx(e.target.value)} />
+              </label>
+              <label className="full-width">New Customer Revenue
+                <input type="number" value={newRevenue} onChange={e=>setNewRevenue(e.target.value)} />
+              </label>
+          <label className="full-width">New Cashback %
+            <input type="number" value={newCashback} onChange={e=>setNewCashback(e.target.value)} />
+          </label>
+        </>
+      )}
+        <div className="checkbox-row full-width">
+          <label className="checkbox">
+            <input type="checkbox" checked={instore} onChange={e=>setInstore(e.target.checked)} /> In-store Offer
+          </label>
+        </div>
+        {instore && (
+          <>
+            <label className="full-width">In-store Transaction Count
+              <input type="number" value={instoreTx} onChange={e=>setInstoreTx(e.target.value)} />
+            </label>
+            <label className="full-width">In-store Revenue
+              <input type="number" value={instoreRevenue} onChange={e=>setInstoreRevenue(e.target.value)} />
+            </label>
+          </>
+        )}
+        <label className="full-width">Other Offer Details
+          <input value={otherDetails} onChange={e=>setOtherDetails(e.target.value)} />
+        </label>
+        <div className="checkbox-row full-width">
+          <label className="checkbox">
+            <input type="radio" name="mode" value="always" checked={mode==='always'} onChange={e=>setMode(e.target.value)} /> Always-on
+          </label>
+          <label className="checkbox">
+              <input type="radio" name="mode" value="tactical" checked={mode==='tactical'} onChange={e=>setMode(e.target.value)} /> Tactical
+            </label>
+          </div>
+          <button type="submit" className="full-width">Calculate Forecast</button>
+        </form>
+        {results && (
+          <div className="results" ref={resultsRef}>
+            <div className="view-toggle">
+              <select value={view} onChange={e=>setView(e.target.value)}>
+                <option value="global">High Level Campaign Metrics</option>
+                {results.offerBreakdown && <option value="offer">By Offer Type</option>}
+                {results.channelBreakdown && <option value="channel">By Channel</option>}
+                <option value="all">View All</option>
+              </select>
+              <button type="button" onClick={downloadPdf}>Download PDF</button>
+            </div>
+            <h2>
+              {retailer
+                ? `${retailer} - ${forecastLength} Month Forecast`
+                : `${forecastLength} Month Forecast`}
+            </h2>
+            {view==='global' && <GlobalView />}
+            {view==='offer' && <OfferView />}
+            {view==='channel' && <ChannelView />}
+            {view==='all' && (
+              <div className="side-by-side">
+                <div>
+                  <h3>High Level Campaign Metrics</h3>
+                  <GlobalView />
+                </div>
+                {results.offerBreakdown && (
+                  <div>
+                    <h3>By Offer Type</h3>
+                    <OfferView />
+                  </div>
+                )}
+                {results.channelBreakdown && (
+                  <div>
+                    <h3>By Channel</h3>
+                    <ChannelView />
+                  </div>
+                )}
+              </div>
+            )}
+            <h3>Monthly Projection</h3>
+            <table className="monthly-table">
+              <thead>
+                <tr>
+                  <th></th>
+                  {results.monthLabels.map((m,i)=>(<th key={i}>{m}</th>))}
+                  <th>Total</th>
+                </tr>
+                <tr className="slider-row">
+                  <th>Adjust</th>
+                  {weights.map((w,i)=>(<th key={i}><input type="range" min="0.5" max="1.5" step="0.01" value={w} onChange={e=>updateWeight(i,parseFloat(e.target.value))} /></th>))}
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {(()=>{
+                  const makeRow=(label,arr,fmt)=>{const tot=arr.reduce((a,b)=>a+b,0);return (<tr><td>{label}</td>{arr.map((v,i)=>(<td key={i}>{fmt(v)}</td>))}<td>{fmt(tot)}</td></tr>);};
+                  return (
+                    <>
+                      {makeRow('Transaction Count',results.monthly.map(m=>m.orders),v=>formatNumber(Math.round(v)))}
+                      {makeRow('Revenue',results.monthly.map(m=>m.revenue),v=>formatCurrency(v,currency))}
+                      {makeRow('Total Cashback',results.monthly.map(m=>m.cashback),v=>formatCurrency(v,currency))}
+                      {makeRow('Net Revenue',results.monthly.map(m=>m.netRevenue),v=>formatCurrency(v,currency))}
+                    </>
+                  );
+                })()}
+              </tbody>
+            </table>
+            <button type="button" onClick={()=>setShowTrc(!showTrc)} className="full-width trc-toggle-btn">
+              {showTrc ? 'Hide' : 'Show'} The Reward Collection Revenue Projections
+            </button>
+            {showTrc && (
+              <div className="trc-section">
+                {mode==='always' ? (
+                  <label className="full-width">TRC Margin %
+                    <input type="number" value={trcMargin} onChange={e=>setTrcMargin(e.target.value)} />
+                  </label>
+                ) : (
+                  <>
+                    <label className="full-width">TRC Margin Existing %
+                      <input type="number" value={trcMarginExisting} onChange={e=>setTrcMarginExisting(e.target.value)} />
+                    </label>
+                    <label className="full-width">TRC Margin New %
+                      <input type="number" value={trcMarginNew} onChange={e=>setTrcMarginNew(e.target.value)} />
+                    </label>
+                  </>
+                )}
+                <table className="monthly-table">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      {results.monthLabels.map((m,i)=>(<th key={i}>{m}</th>))}
+                      <th>Total</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(()=>{
+                      const makeRow=(label,arr,fmt)=>{const tot=arr.reduce((a,b)=>a+b,0);return (<tr><td>{label}</td>{arr.map((v,i)=>(<td key={i}>{fmt(v)}</td>))}<td>{fmt(tot)}</td></tr>);};
+                      return (
+                        <>
+                          {makeRow('Transaction Count',results.monthly.map(m=>m.orders),v=>formatNumber(Math.round(v)))}
+                          {makeRow('Revenue',results.monthly.map(m=>m.revenue),v=>formatCurrency(v,currency))}
+                          {makeRow('Total Cashback',results.monthly.map(m=>m.cashback),v=>formatCurrency(v,currency))}
+                          {makeRow('Net Revenue',results.monthly.map(m=>m.netRevenue),v=>formatCurrency(v,currency))}
+                          {makeRow('TRC Revenue',results.trcMonthly||[],v=>formatCurrency(v,currency))}
+                        </>
+                      );
+                    })()}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <p className="disclaimer">
+              <strong>Disclaimer:</strong><br />
+              All forecasts are based on historical performance data and may fluctuate depending on a range of variables. These figures are intended as directional guidance rather than fixed budgets, offering insight into the potential success of your campaign with The Reward Collection.<br /><br />
+              We’re looking forward to getting this campaign up and running with {publisher} and continuing to build on our partnership.<br /><br />
+              Thanks,<br />
+              {manager.charAt(0).toUpperCase()+manager.slice(1)}<br />
+              {manager}@thewardcollection.com
+            </p>
+            <button type="button" onClick={saveForecast} className="save-btn">Save Forecast</button>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/pages/publishers.js
+++ b/pages/publishers.js
@@ -1,0 +1,136 @@
+import { useState, useEffect } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { usePublishers, DEFAULT_PUBLISHERS } from '../lib/usePublishers';
+
+export default function PublisherAdmin() {
+  const [publishers, setPublishers] = usePublishers();
+  const [theme, setTheme] = useState('light');
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+  const [editing, setEditing] = useState(null);
+  const [form, setForm] = useState({
+    network: '',
+    sub: '',
+    regions: 'UK',
+    reach: '',
+    newCustomers: false,
+  });
+
+  const resetForm = () => {
+    setEditing(null);
+    setForm({ network: '', sub: '', regions: 'UK', reach: '', newCustomers: false });
+  };
+
+  const startEdit = (p) => {
+    setEditing(p.id);
+    setForm({
+      network: p.network,
+      sub: p.sub,
+      regions: p.regions.join(','),
+      reach: p.reach,
+      newCustomers: p.newCustomers,
+    });
+  };
+
+  const savePublisher = (e) => {
+    e.preventDefault();
+    const regions = form.regions.split(',').map((r) => r.trim().toUpperCase());
+    const updated = { ...form, regions, reach: parseInt(form.reach, 10) || 0, id: editing ?? Date.now() };
+    setPublishers((prev) => {
+      if (editing) {
+        return prev.map((p) => (p.id === editing ? updated : p));
+      }
+      return [...prev, updated];
+    });
+    resetForm();
+  };
+
+  const removePublisher = (id) => {
+    if (confirm('Delete publisher?')) {
+      setPublishers((prev) => prev.filter((p) => p.id !== id));
+    }
+  };
+
+  const restoreDefaults = () => {
+    if (confirm('Restore default data?')) {
+      setPublishers(DEFAULT_PUBLISHERS);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Publisher Data</title>
+      </Head>
+      <main className="container">
+        <div className="top-bar">
+          <div className="nav-links">
+            <Link href="/">Forecasting</Link>
+            <Link href="/publishers">Publishers</Link>
+            <Link href="/publisher-forecast">Publisher Forecasts</Link>
+            <Link href="/saved-forecasts">Saved Forecasts</Link>
+            <button type="button" onClick={restoreDefaults}>Restore Defaults</button>
+          </div>
+          <div className="theme-switch">
+            <button type="button" onClick={() => setTheme(theme==='dark'?'light':'dark')}>
+              {theme==='dark'?'Light Mode':'Dark Mode'}
+            </button>
+          </div>
+        </div>
+        <h1>Publishers</h1>
+        <table className="monthly-table">
+          <thead>
+            <tr>
+              <th>Network</th>
+              <th>Sub Publishers</th>
+              <th>Regions</th>
+              <th>Reach</th>
+              <th>New Customers</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {publishers.map((p) => (
+              <tr key={p.id}>
+                <td>{p.network}</td>
+                <td>{p.sub}</td>
+                <td>{p.regions.join(', ')}</td>
+                <td>{p.reach.toLocaleString()}</td>
+                <td>{p.newCustomers ? 'Yes' : 'No'}</td>
+                <td>
+                  <button type="button" onClick={() => startEdit(p)}>Edit</button>{' '}
+                  <button type="button" onClick={() => removePublisher(p.id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <form onSubmit={savePublisher} className="form" style={{ marginTop: '20px' }}>
+          <h3>{editing ? 'Edit Publisher' : 'Add Publisher'}</h3>
+          <label className="full-width">
+            Network
+            <input value={form.network} onChange={(e) => setForm({ ...form, network: e.target.value })} required />
+          </label>
+          <label className="full-width">
+            Sub Publishers
+            <input value={form.sub} onChange={(e) => setForm({ ...form, sub: e.target.value })} required />
+          </label>
+          <label>
+            Regions (comma separated e.g. UK,US)
+            <input value={form.regions} onChange={(e) => setForm({ ...form, regions: e.target.value })} />
+          </label>
+          <label>
+            Reach
+            <input type="number" value={form.reach} onChange={(e) => setForm({ ...form, reach: e.target.value })} />
+          </label>
+          <label className="checkbox">
+            <input type="checkbox" checked={form.newCustomers} onChange={(e) => setForm({ ...form, newCustomers: e.target.checked })} /> New Customers
+          </label>
+          <button type="submit" className="full-width">{editing ? 'Save' : 'Add'}</button>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/pages/saved-forecasts.js
+++ b/pages/saved-forecasts.js
@@ -42,9 +42,7 @@ export default function SavedForecasts() {
               {forecasts.map((f) => (
                 <tr key={f.id}>
                   <td>
-                    <Link href={`/saved-forecasts/${f.id}`} legacyBehavior>
-                      <a className="row-link">{f.retailer || f.publisher || 'Forecast'}</a>
-                    </Link>
+                    <a className="row-link" href={`/saved-forecasts/${f.id}`}>{f.retailer || f.publisher || 'Forecast'}</a>
                   </td>
                   <td>{new Date(f.savedAt).toLocaleString()}</td>
                   <td>

--- a/pages/saved-forecasts.js
+++ b/pages/saved-forecasts.js
@@ -42,7 +42,9 @@ export default function SavedForecasts() {
               {forecasts.map((f) => (
                 <tr key={f.id}>
                   <td>
-                    <a className="row-link" href={`/saved-forecasts/${f.id}`}>{f.retailer || f.publisher || 'Forecast'}</a>
+                    <Link className="row-link" href={`/saved-forecasts/${f.id}`}>
+                      {f.retailer || f.publisher || 'Forecast'}
+                    </Link>
                   </td>
                   <td>{new Date(f.savedAt).toLocaleString()}</td>
                   <td>

--- a/pages/saved-forecasts.js
+++ b/pages/saved-forecasts.js
@@ -7,6 +7,13 @@ export default function SavedForecasts() {
   const [forecasts, , removeForecast] = useSavedForecasts();
   const [theme,setTheme] = useState('light');
   useEffect(()=>{document.documentElement.dataset.theme = theme;},[theme]);
+  if (!forecasts) {
+    return (
+      <main className="container">
+        <p>Loading...</p>
+      </main>
+    );
+  }
   return (
     <>
       <Head>
@@ -48,7 +55,7 @@ export default function SavedForecasts() {
                   </td>
                   <td>{new Date(f.savedAt).toLocaleString()}</td>
                   <td>
-                    <button type="button" onClick={() => removeForecast(f.id)}>
+                    <button type="button" onClick={async () => await removeForecast(f.id)}>
                       Delete
                     </button>
                   </td>

--- a/pages/saved-forecasts.js
+++ b/pages/saved-forecasts.js
@@ -1,0 +1,63 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
+import { useSavedForecasts } from '../lib/useSavedForecasts';
+
+export default function SavedForecasts() {
+  const [forecasts, , removeForecast] = useSavedForecasts();
+  const [theme,setTheme] = useState('light');
+  useEffect(()=>{document.documentElement.dataset.theme = theme;},[theme]);
+  return (
+    <>
+      <Head>
+        <title>Saved Forecasts</title>
+      </Head>
+      <main className="container">
+        <div className="top-bar">
+          <div className="nav-links">
+            <Link href="/">Forecasting</Link>
+            <Link href="/publishers">Publishers</Link>
+            <Link href="/publisher-forecast">Publisher Forecasts</Link>
+            <Link href="/saved-forecasts">Saved Forecasts</Link>
+          </div>
+          <div className="theme-switch">
+            <button type="button" onClick={() => setTheme(theme==='dark'?'light':'dark')}>
+              {theme==='dark'?'Light Mode':'Dark Mode'}
+            </button>
+          </div>
+        </div>
+        <h1>Saved Forecasts</h1>
+        {forecasts.length === 0 ? (
+          <p>No saved forecasts.</p>
+        ) : (
+          <table className="monthly-table">
+            <thead>
+              <tr>
+                <th>Retailer/Publisher</th>
+                <th>Date Saved</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {forecasts.map((f) => (
+                <tr key={f.id}>
+                  <td>
+                    <Link href={`/saved-forecasts/${f.id}`} legacyBehavior>
+                      <a className="row-link">{f.retailer || f.publisher || 'Forecast'}</a>
+                    </Link>
+                  </td>
+                  <td>{new Date(f.savedAt).toLocaleString()}</td>
+                  <td>
+                    <button type="button" onClick={() => removeForecast(f.id)}>
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </main>
+    </>
+  );
+}

--- a/pages/saved-forecasts/[id].js
+++ b/pages/saved-forecasts/[id].js
@@ -27,17 +27,18 @@ export default function ViewForecast() {
   const router = useRouter();
   const { id } = router.query;
   const [forecasts] = useSavedForecasts();
-  const forecast = forecasts.find((f) => f.id === Number(id));
   const resultsRef = useRef(null);
 
+  if (!router.isReady || forecasts.length === 0) {
+    return (
+      <main className="container">
+        <p>Loading...</p>
+      </main>
+    );
+  }
+
+  const forecast = forecasts.find((f) => f.id === Number(id));
   if (!forecast) {
-    if (forecasts.length === 0) {
-      return (
-        <main className="container">
-          <p>Loading...</p>
-        </main>
-      );
-    }
     return (
       <main className="container">
         <p>Forecast not found.</p>

--- a/pages/saved-forecasts/[id].js
+++ b/pages/saved-forecasts/[id].js
@@ -236,7 +236,7 @@ export default function ViewForecast() {
           </button>
           <button type="button" onClick={downloadPdf}>Download PDF</button>
         </div>
-        <div ref={resultsRef}>
+        <div className="results" ref={resultsRef}>
           <h2>
             {retailer ? `${retailer} - ${forecast.inputs?.forecastLength || monthLabels.length} Month Forecast` : 'Forecast'}
           </h2>

--- a/pages/saved-forecasts/[id].js
+++ b/pages/saved-forecasts/[id].js
@@ -1,0 +1,340 @@
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRef, useState, useEffect } from 'react';
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
+import { useSavedForecasts } from '../../lib/useSavedForecasts';
+
+const CURRENCY_SYMBOLS = { GBP: '£', USD: '$', EUR: '€' };
+
+function formatNumber(n) {
+  return n.toLocaleString();
+}
+
+function formatCurrency(n, code) {
+  const symbol = CURRENCY_SYMBOLS[code] || '';
+  return (
+    symbol +
+    n.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  );
+}
+
+export default function ViewForecast() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [forecasts] = useSavedForecasts();
+  const forecast = forecasts.find((f) => f.id === Number(id));
+  const resultsRef = useRef(null);
+
+  if (!forecast) {
+    if (forecasts.length === 0) {
+      return (
+        <main className="container">
+          <p>Loading...</p>
+        </main>
+      );
+    }
+    return (
+      <main className="container">
+        <p>Forecast not found.</p>
+        <Link href="/saved-forecasts">Back</Link>
+      </main>
+    );
+  }
+
+  const { type, retailer, publisher, manager, rep, results } = forecast;
+  const [view,setView] = useState('global');
+  const [theme,setTheme] = useState('light');
+  useEffect(()=>{document.documentElement.dataset.theme = theme;},[theme]);
+
+  const downloadPdf = async () => {
+    if (!resultsRef.current) return;
+    const viewToggle = resultsRef.current.querySelector('.view-toggle');
+    const prevView = viewToggle ? viewToggle.style.display : '';
+    if (viewToggle) viewToggle.style.display = 'none';
+    const canvas = await html2canvas(resultsRef.current);
+    if (viewToggle) viewToggle.style.display = prevView;
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF('p', 'mm', 'a4');
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const imgWidth = pageWidth;
+    const imgHeight = (canvas.height * imgWidth) / canvas.width;
+    let position = 0;
+    pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+    let heightLeft = imgHeight - pdf.internal.pageSize.getHeight();
+    while (heightLeft > 0) {
+      position -= pdf.internal.pageSize.getHeight();
+      pdf.addPage();
+      pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+      heightLeft -= pdf.internal.pageSize.getHeight();
+    }
+    const fileName = retailer
+      ? `${retailer}-forecast.pdf`
+      : 'forecast.pdf';
+    pdf.save(fileName);
+  };
+
+  const editPath =
+    type === 'publisher'
+      ? `/publisher-forecast?edit=${forecast.id}`
+      : `/?edit=${forecast.id}`;
+
+  const GlobalView = () => (
+    <table className="summary-table">
+      <tbody>
+        {publisher && (
+          <tr>
+            <th>Publisher</th>
+            <td>{publisher}</td>
+          </tr>
+        )}
+        <tr>
+          <th>Transaction Count</th>
+          <td>{formatNumber(Math.round(results.total.orders))}</td>
+        </tr>
+        <tr>
+          <th>Revenue</th>
+          <td>{formatCurrency(results.total.revenue, results.currency || forecast.currency)}</td>
+        </tr>
+        <tr>
+          <th>Total Cashback</th>
+          <td>{formatCurrency(results.total.cashback, results.currency || forecast.currency)}</td>
+        </tr>
+        {results.cashbackRates && (
+          (() => {
+            const ex = results.cashbackRates.existing || 0;
+            const nw = results.cashbackRates.new || 0;
+            if (ex > 0 && nw > 0) {
+              return (
+                <>
+                  <tr><th>New Customer Total Cashback</th><td>{nw}%</td></tr>
+                  <tr><th>Existing Customer Total Cashback</th><td>{ex}%</td></tr>
+                </>
+              );
+            }
+            const rate = ex > 0 ? ex : nw;
+            return rate ? (<tr><th>Total Cashback</th><td>{rate}%</td></tr>) : null;
+          })()
+        )}
+        <tr>
+          <th>Net Revenue</th>
+          <td>{formatCurrency(results.total.netRevenue, results.currency || forecast.currency)}</td>
+        </tr>
+        {results.total.aov && (
+          <tr>
+            <th>Average Order Value</th>
+            <td>{formatCurrency(results.total.aov, results.currency || forecast.currency)}</td>
+          </tr>
+        )}
+        {forecast.inputs?.otherDetails && (
+          <tr>
+            <th>Other Offer Details</th>
+            <td>{forecast.inputs.otherDetails}</td>
+          </tr>
+        )}
+        <tr>
+          <th>ROAS</th>
+          <td>{results.total.roas.toFixed(2)}x</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+
+  const OfferView = () => (
+    results.offerBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>{type === 'publisher' ? 'Type' : 'Type'}</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.offerBreakdown).map(([t, d]) => (
+            <tr key={t}>
+              <td>{t}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue, results.currency || forecast.currency)}</td>
+              <td>{formatCurrency(d.cashback, results.currency || forecast.currency)}</td>
+              <td>{formatCurrency(d.netRevenue, results.currency || forecast.currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+  const ChannelView = () => (
+    results.channelBreakdown && (
+      <table className="monthly-table">
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Orders</th>
+            <th>Revenue</th>
+            <th>Total Cashback</th>
+            <th>Net Revenue</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results.channelBreakdown).map(([c, d]) => (
+            <tr key={c}>
+              <td>{c}</td>
+              <td>{formatNumber(Math.round(d.orders))}</td>
+              <td>{formatCurrency(d.revenue, results.currency || forecast.currency)}</td>
+              <td>{formatCurrency(d.cashback, results.currency || forecast.currency)}</td>
+              <td>{formatCurrency(d.netRevenue, results.currency || forecast.currency)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  );
+
+  return (
+    <>
+      <Head>
+        <title>Saved Forecast</title>
+      </Head>
+      <main className="container">
+        <div className="top-bar">
+          <div className="nav-links">
+            <Link href="/">Forecasting</Link>
+            <Link href="/publishers">Publishers</Link>
+            <Link href="/publisher-forecast">Publisher Forecasts</Link>
+            <Link href="/saved-forecasts">Saved Forecasts</Link>
+          </div>
+          <div className="theme-switch">
+            <button type="button" onClick={() => setTheme(theme==='dark'?'light':'dark')}>
+              {theme==='dark'?'Light Mode':'Dark Mode'}
+            </button>
+          </div>
+        </div>
+        <h1>Saved Forecast</h1>
+        <div className="view-toggle">
+          <select value={view} onChange={e=>setView(e.target.value)}>
+            <option value="global">High Level Campaign Metrics</option>
+            {results.offerBreakdown && <option value="offer">By Offer Type</option>}
+            {results.channelBreakdown && <option value="channel">By Channel</option>}
+            <option value="all">View All</option>
+          </select>
+          <button type="button" onClick={() => router.push(editPath)}>
+            Edit Forecast
+          </button>
+          <button type="button" onClick={downloadPdf}>Download PDF</button>
+        </div>
+        <div ref={resultsRef}>
+          <h2>
+            {retailer ? `${retailer} - ${forecast.inputs?.forecastLength || results.monthLabels.length} Month Forecast` : 'Forecast'}
+          </h2>
+          {view==='global' && <GlobalView />}
+          {view==='offer' && <OfferView />}
+          {view==='channel' && <ChannelView />}
+          {view==='all' && (
+            <div className="side-by-side">
+              <div>
+                <h3>High Level Campaign Metrics</h3>
+                <GlobalView />
+              </div>
+              {results.offerBreakdown && (
+                <div>
+                  <h3>By Offer Type</h3>
+                  <OfferView />
+                </div>
+              )}
+              {results.channelBreakdown && (
+                <div>
+                  <h3>By Channel</h3>
+                  <ChannelView />
+                </div>
+              )}
+            </div>
+          )}
+          {results.monthly && (
+            <>
+              <h3>Monthly Projection</h3>
+              <table className="monthly-table">
+                <thead>
+                  <tr>
+                    <th></th>
+                    {results.monthLabels.map((m, i) => (
+                      <th key={i}>{m}</th>
+                    ))}
+                    <th>Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(() => {
+                    const makeRow = (label, arr, formatter) => {
+                      const total = arr.reduce((a, b) => a + b, 0);
+                      return (
+                        <tr>
+                          <td>{label}</td>
+                          {arr.map((v, i) => (
+                            <td key={i}>{formatter(v)}</td>
+                          ))}
+                          <td>{formatter(total)}</td>
+                        </tr>
+                      );
+                    };
+                    return (
+                      <>
+                        {makeRow(
+                          'Orders',
+                          results.monthly.map((m) => m.orders),
+                          (v) => formatNumber(Math.round(v))
+                        )}
+                        {makeRow(
+                          'Revenue',
+                          results.monthly.map((m) => m.revenue),
+                          (v) =>
+                            formatCurrency(
+                              v,
+                              results.currency || forecast.currency
+                            )
+                        )}
+                        {makeRow(
+                          'Total Cashback',
+                          results.monthly.map((m) => m.cashback),
+                          (v) =>
+                            formatCurrency(
+                              v,
+                              results.currency || forecast.currency
+                            )
+                        )}
+                  {makeRow(
+                          'Net Revenue',
+                          results.monthly.map((m) => m.netRevenue),
+                          (v) =>
+                            formatCurrency(
+                              v,
+                              results.currency || forecast.currency
+                            )
+                        )}
+                      </>
+                    );
+                  })()}
+                </tbody>
+              </table>
+            </>
+          )}
+          <p className="disclaimer">
+            <strong>Disclaimer:</strong><br />
+            All forecasts are based on historical performance data and may fluctuate depending on a range of variables. These figures are intended as directional guidance rather than fixed budgets, offering insight into the potential success of your campaign with The Reward Collection.<br /><br />
+            We’re looking forward to getting this campaign up and running with {publisher} and continuing to build on our partnership.<br /><br />
+            Thanks,<br />
+            {(manager || rep).charAt(0).toUpperCase() + (manager || rep).slice(1)}<br />
+            {(manager || rep)}@thewardcollection.com
+          </p>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/pages/saved-forecasts/[id].js
+++ b/pages/saved-forecasts/[id].js
@@ -46,7 +46,9 @@ export default function ViewForecast() {
     );
   }
 
-  const { type, retailer, publisher, manager, rep, results } = forecast;
+  const { type, retailer, publisher, manager, rep, results = {} } = forecast;
+  const monthLabels = results.monthLabels ||
+    (results.monthly ? results.monthly.map((_, i) => `Month ${i + 1}`) : []);
   const [view,setView] = useState('global');
   const [theme,setTheme] = useState('light');
   useEffect(()=>{document.documentElement.dataset.theme = theme;},[theme]);
@@ -232,7 +234,7 @@ export default function ViewForecast() {
         </div>
         <div ref={resultsRef}>
           <h2>
-            {retailer ? `${retailer} - ${forecast.inputs?.forecastLength || results.monthLabels.length} Month Forecast` : 'Forecast'}
+            {retailer ? `${retailer} - ${forecast.inputs?.forecastLength || monthLabels.length} Month Forecast` : 'Forecast'}
           </h2>
           {view==='global' && <GlobalView />}
           {view==='offer' && <OfferView />}
@@ -264,7 +266,7 @@ export default function ViewForecast() {
                 <thead>
                   <tr>
                     <th></th>
-                    {results.monthLabels.map((m, i) => (
+                    {monthLabels.map((m, i) => (
                       <th key={i}>{m}</th>
                     ))}
                     <th>Total</th>

--- a/pages/saved-forecasts/[id].js
+++ b/pages/saved-forecasts/[id].js
@@ -29,7 +29,7 @@ export default function ViewForecast() {
   const [forecasts] = useSavedForecasts();
   const resultsRef = useRef(null);
 
-  if (!router.isReady || forecasts.length === 0) {
+  if (!router.isReady || !forecasts) {
     return (
       <main className="container">
         <p>Loading...</p>

--- a/pages/saved-forecasts/[id].js
+++ b/pages/saved-forecasts/[id].js
@@ -9,14 +9,14 @@ import { useSavedForecasts } from '../../lib/useSavedForecasts';
 const CURRENCY_SYMBOLS = { GBP: '£', USD: '$', EUR: '€' };
 
 function formatNumber(n) {
-  return n.toLocaleString();
+  return Number(n || 0).toLocaleString('en-US');
 }
 
 function formatCurrency(n, code) {
   const symbol = CURRENCY_SYMBOLS[code] || '';
   return (
     symbol +
-    n.toLocaleString(undefined, {
+    Number(n || 0).toLocaleString('en-US', {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     })
@@ -85,7 +85,9 @@ export default function ViewForecast() {
       ? `/publisher-forecast?edit=${forecast.id}`
       : `/?edit=${forecast.id}`;
 
-  const GlobalView = () => (
+  const GlobalView = () => {
+    const total = results.total || {};
+    return (
     <table className="summary-table">
       <tbody>
         {publisher && (
@@ -96,15 +98,15 @@ export default function ViewForecast() {
         )}
         <tr>
           <th>Transaction Count</th>
-          <td>{formatNumber(Math.round(results.total.orders))}</td>
+          <td>{formatNumber(Math.round(total.orders || 0))}</td>
         </tr>
         <tr>
           <th>Revenue</th>
-          <td>{formatCurrency(results.total.revenue, results.currency || forecast.currency)}</td>
+          <td>{formatCurrency(total.revenue, results.currency || forecast.currency)}</td>
         </tr>
         <tr>
           <th>Total Cashback</th>
-          <td>{formatCurrency(results.total.cashback, results.currency || forecast.currency)}</td>
+          <td>{formatCurrency(total.cashback, results.currency || forecast.currency)}</td>
         </tr>
         {results.cashbackRates && (
           (() => {
@@ -124,12 +126,12 @@ export default function ViewForecast() {
         )}
         <tr>
           <th>Net Revenue</th>
-          <td>{formatCurrency(results.total.netRevenue, results.currency || forecast.currency)}</td>
+          <td>{formatCurrency(total.netRevenue, results.currency || forecast.currency)}</td>
         </tr>
-        {results.total.aov && (
+        {total.aov && (
           <tr>
             <th>Average Order Value</th>
-            <td>{formatCurrency(results.total.aov, results.currency || forecast.currency)}</td>
+            <td>{formatCurrency(total.aov, results.currency || forecast.currency)}</td>
           </tr>
         )}
         {forecast.inputs?.otherDetails && (
@@ -140,11 +142,12 @@ export default function ViewForecast() {
         )}
         <tr>
           <th>ROAS</th>
-          <td>{results.total.roas.toFixed(2)}x</td>
+          <td>{(total.roas || 0).toFixed(2)}x</td>
         </tr>
       </tbody>
     </table>
   );
+  };
 
   const OfferView = () => (
     results.offerBreakdown && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,14 +1,41 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
+:root {
+  /* TRC brand blue */
+  --brand: #005eb8;
+  --bg: #0b0b0e;
+  --text: #e4e4e4;
+  --panel-bg: #121214;
+  --input-bg: #1c1c1f;
+  --border-color: #333;
+}
+
+[data-theme='light'] {
+  --bg: #ffffff;
+  --text: #111111;
+  --panel-bg: #f5f5f5;
+  --input-bg: #ffffff;
+  --border-color: #cccccc;
+}
 
 body {
-  background-color: #0c0c0f;
-  color: white;
-  font-family: 'Arial', sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
 }
 
+a {
+  color: var(--brand);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
 button {
-  background-color: #007bff;
+  background-color: var(--brand);
   border: none;
   padding: 12px 24px;
   border-radius: 8px;
@@ -16,8 +43,220 @@ button {
   cursor: pointer;
   color: white;
   margin-top: 20px;
+  transition: background-color 0.2s ease, transform 0.1s ease;
 }
 
 button:hover {
-  background-color: #0056b3;
+  background-color: #5a0145;
+  transform: translateY(-2px);
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 50px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+}
+
+form.form {
+  background: var(--panel-bg);
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.6);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+h1 {
+  text-align: center;
+  color: var(--brand);
+}
+
+.region-group {
+  margin-bottom: 16px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  border: 1px solid var(--border-color);
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.region-group legend {
+  padding: 0 6px;
+  color: var(--brand);
+}
+
+form.form label {
+  display: block;
+  margin-bottom: 16px;
+}
+
+form.form input,
+form.form select {
+  width: 100%;
+  padding: 10px;
+  margin-top: 4px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text);
+}
+
+form.form input[type='checkbox'] {
+  width: auto;
+  accent-color: var(--brand);
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.checkbox-row {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+
+form.form label.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.results {
+  margin-top: 30px;
+  background: var(--panel-bg);
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+.results h2 {
+  margin-top: 0;
+  color: var(--brand);
+}
+
+.results h3 {
+  color: var(--brand);
+}
+
+.reach-input {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.view-toggle {
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.view-toggle button {
+  margin-top: 0;
+  margin-left: 10px;
+}
+
+.results table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+.results th,
+.results td {
+  border: 1px solid var(--border-color);
+  padding: 12px;
+}
+
+.results table {
+  font-size: 1.1rem;
+}
+
+.monthly-table {
+  font-size: 1.3rem;
+}
+
+.totals-row {
+  font-weight: 600;
+  background: var(--input-bg);
+}
+
+
+
+.theme-switch {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}
+
+.nav-links {
+  display: flex;
+  gap: 20px;
+}
+.nav-links a {
+  margin-right: 0;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+
+.theme-switch button {
+  margin-top: 0;
+}
+.theme-switch input {
+  margin-top: 8px;
+  padding: 6px;
+  width: 150px;
+}
+
+.side-by-side {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+}
+
+.side-by-side > * {
+  width: 100%;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 8px;
+  border: 1px solid var(--border-color);
+}
+
+.row-link {
+  display: block;
+  width: 100%;
+}
+
+.disclaimer {
+  margin-top: 20px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.slider-row input[type='range'] {
+  width: 100px;
+}
+
+.trc-section {
+  margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- ensure each saved forecast link uses anchor to navigate
- show loading indicator while retrieving forecasts
- style forecast list links to fill the table cell

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d19d613cc8320a7265718b411ce02