### PR TITLE
Sync local storage with Supabase forecasts

### DIFF
--- a/lib/useSavedForecasts.js
+++ b/lib/useSavedForecasts.js
@@ -5,45 +5,83 @@ export function useSavedForecasts() {
   const [forecasts, setForecasts] = useState(null);
 
   useEffect(() => {
+    const stored = localStorage.getItem('forecasts');
+    if (stored) {
+      try {
+        setForecasts(JSON.parse(stored));
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
     async function load() {
       const { data, error } = await supabase
         .from('forecasts')
         .select('*')
         .order('id', { ascending: false });
       if (!error) {
-        setForecasts(
-          (data || []).map((row) => ({
-            id: row.id,
-            savedAt: row.created_at,
-            ...row.data,
-          }))
-        );
+        const loaded = (data || []).map((row) => ({
+          id: row.id,
+          savedAt: row.saved_at || row.created_at,
+          ...row.data,
+        }));
+        setForecasts(loaded);
+        localStorage.setItem('forecasts', JSON.stringify(loaded));
       } else {
         console.error(error);
-        setForecasts([]);
+        if (!stored) setForecasts([]);
       }
     }
     load();
   }, []);
 
   const addForecast = async (data) => {
+    const id = Date.now();
+    const optimistic = { id, savedAt: Date.now(), ...data };
+    setForecasts((prev) => {
+      const next = [optimistic, ...(prev || [])];
+      localStorage.setItem('forecasts', JSON.stringify(next));
+      return next;
+    });
     const { data: inserted, error } = await supabase
       .from('forecasts')
-      .insert([{ data }])
+      .insert([
+        {
+          id,
+          type: data.type,
+          retailer: data.retailer,
+          publisher: data.publisher,
+          rep: data.rep,
+          manager: data.manager,
+          inputs: data.inputs,
+          results: data.results,
+          currency: data.currency,
+          data,
+        },
+      ])
       .select()
       .single();
     if (!error && inserted) {
-      setForecasts((prev) => [
-        ...(prev || []),
-        { id: inserted.id, savedAt: inserted.created_at, ...data },
-      ]);
+      setForecasts((prev) => {
+        const next = (prev || []).map((f) =>
+          f.id === id
+            ? { ...f, savedAt: inserted.saved_at || inserted.created_at }
+            : f
+        );
+        localStorage.setItem('forecasts', JSON.stringify(next));
+        return next;
+      });
     }
   };
 
   const removeForecast = async (id) => {
     const { error } = await supabase.from('forecasts').delete().eq('id', id);
     if (!error) {
-      setForecasts((prev) => (prev || []).filter((f) => f.id !== id));
+      setForecasts((prev) => {
+        const next = (prev || []).filter((f) => f.id !== id);
+        localStorage.setItem('forecasts', JSON.stringify(next));
+        return next;
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- keep a cached list of forecasts in localStorage
- insert forecasts with explicit ids and metadata
- update optimistic entries with `saved_at` from Supabase
- keep localStorage in sync when loading and deleting forecasts

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a094298048320b8e3b7ca8059124e